### PR TITLE
fix: footnote popup no longer depends on the Popover API

### DIFF
--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -186,6 +186,30 @@ test('clicking a tagged word opens the study sidebar', async ({ page }) => {
 	await expect(page).toHaveURL(/#G25\/geliebt\/16$/);
 });
 
+test('clicking a footnote marker opens its note without relying on the Popover API', async ({
+	page
+}) => {
+	await page.goto('/Joh3');
+
+	// Force the same code path devices without Popover API support hit, so a regression here is
+	// caught even when the browser under test does support it.
+	await page.addInitScript(() => {
+		// @ts-expect-error simulating an older WebView for the test
+		delete HTMLElement.prototype.showPopover;
+	});
+	await page.reload();
+
+	const marker = page.locator('button.footnote-marker').first();
+	await marker.click();
+
+	const note = page.getByRole('note');
+	await expect(note).toBeVisible();
+	await expect(note).toContainText('so sehr');
+
+	await marker.click();
+	await expect(note).not.toBeVisible();
+});
+
 test('the Strong page lists every occurrence', async ({ page }) => {
 	await page.goto('/G2316');
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -43,7 +43,7 @@ const GERMAN = `<?xml version="1.0" encoding="utf-8"?>
 	</BIBLEBOOK>
 	<BIBLEBOOK bnumber="43">
 		<CHAPTER cnumber="3">
-			<VERS vnumber="16">Denn also hat <gr str="2316">Gott </gr> die <gr str="2889">Welt </gr><gr str="25">geliebt </gr>, daß er seinen <gr str="5207">Sohn </gr> gab.</VERS>
+			<VERS vnumber="16">Denn also hat <gr str="2316">Gott </gr> die <gr str="2889">Welt </gr><gr str="25">geliebt </gr><note n="*">o. so sehr</note>, daß er seinen <gr str="5207">Sohn </gr> gab.</VERS>
 			<VERS vnumber="17">Denn <gr str="2316">Gott </gr> hat seinen <gr str="5207">Sohn </gr> nicht gesandt, um zu richten.</VERS>
 		</CHAPTER>
 	</BIBLEBOOK>

--- a/src/lib/components/Footnote.svelte
+++ b/src/lib/components/Footnote.svelte
@@ -1,4 +1,11 @@
+<script module lang="ts">
+	// Only one footnote popup should be open at a time; each instance registers how to close
+	// itself here so opening a new one dismisses whichever was open before.
+	let closeOpen: (() => void) | null = null;
+</script>
+
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { t } from '$lib/i18n';
 
 	let {
@@ -9,16 +16,19 @@
 		text: string;
 	} = $props();
 
+	let open = $state(false);
 	let popup = $state<HTMLSpanElement | undefined>();
 	let trigger = $state<HTMLButtonElement | undefined>();
 
-	function toggle(): void {
-		if (!popup) return;
-		if (popup.matches(':popover-open')) {
-			popup.hidePopover();
+	async function toggle(): Promise<void> {
+		if (open) {
+			open = false;
 			return;
 		}
-		popup.showPopover();
+		closeOpen?.();
+		open = true;
+		closeOpen = () => (open = false);
+		await tick();
 		place();
 	}
 
@@ -40,9 +50,27 @@
 		popup.style.left = `${left}px`;
 		popup.style.top = `${top}px`;
 	}
+
+	function onWindowKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Escape') open = false;
+	}
+
+	// The trigger's own click already toggles `open`; without this exclusion an outside click
+	// would close it here first and then the click handler would immediately reopen it.
+	function onWindowClick(event: MouseEvent): void {
+		if (!open) return;
+		const target = event.target as HTMLElement | null;
+		if (!target) return;
+		if (popup?.contains(target) || target.closest('.footnote-marker')) return;
+		open = false;
+	}
 </script>
 
-<svelte:window onresize={() => popup?.matches(':popover-open') && place()} />
+<svelte:window
+	onresize={() => open && place()}
+	onclick={onWindowClick}
+	onkeydown={onWindowKeydown}
+/>
 
 <button
 	bind:this={trigger}
@@ -50,11 +78,14 @@
 	class="footnote-marker"
 	aria-label={t('verse.footnote', { marker: marker || '*' })}
 	aria-haspopup="dialog"
+	aria-expanded={open}
 	onclick={toggle}
 >
 	{marker || '*'}
 </button>
-<span bind:this={popup} popover="auto" role="note" class="footnote-popup">{text}</span>
+{#if open}
+	<span bind:this={popup} role="note" class="footnote-popup">{text}</span>
+{/if}
 
 <style>
 	.footnote-marker {
@@ -87,6 +118,7 @@
 
 	.footnote-popup {
 		position: fixed;
+		z-index: 50;
 		inset: auto;
 		width: max-content;
 		max-width: min(24rem, calc(100vw - 1rem));
@@ -101,10 +133,6 @@
 		font-weight: 400;
 		line-height: 1.45;
 		color: var(--color-stone-700);
-	}
-
-	.footnote-popup:not(:popover-open) {
-		display: none;
 	}
 
 	:global(.dark) .footnote-popup {


### PR DESCRIPTION
## Summary
- Footnote markers use the native Popover API (`showPopover`/`hidePopover`/`:popover-open`). On WebViews that predate it — plausible on a Boox e-ink Android tablet, which tends to ship an old/limited Chromium WebView — calling `showPopover()` throws, silently aborting the click with no visible feedback. Chrome DevTools' touch emulation runs on full desktop Chrome, so it doesn't reproduce this.
- Replaced the Popover-API dependency with plain component state, using the same manual Escape/outside-click dismissal pattern already used by the study sidebar (`StudySidebar.svelte`). Only one footnote popup stays open at a time via a small module-scoped registry.

Addresses the todo.md item: "Auf meinem Boox-Tablet kann ich immer noch nicht per Stift / Touch auf die Hinweise (* oder Buchstaben) klicken."

## Test plan
- [x] `pnpm test:unit`
- [x] `pnpm test:e2e` (added a new test that deletes `HTMLElement.prototype.showPopover` before navigating, to pin the no-Popover-API code path; also verifies open/close and note text)
- [x] `pnpm check` / `pnpm lint`
- [ ] Manual verification on the actual Boox tablet (I can't do this myself — please confirm on-device)