### PR TITLE
fix: recover from mis-encoded reference URLs, make Startseite a real home link

### DIFF
--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -387,3 +387,22 @@ test('legacy URLs from the previous site still resolve', async ({ page }) => {
 	await page.goto('/Joh3/trans/0_2');
 	await expect(page).toHaveURL(/\/Joh3$/);
 });
+
+test('a reference percent-encoded as Latin-1 does not crash the page', async ({ page }) => {
+	// "1K%F6n16" is "1Kön16" (1.Könige 16) with "ö" mis-encoded as Latin-1 (0xF6) instead of UTF-8
+	// (%C3%B6) — something old browsers and stale bookmarks still produce.
+	const response = await page.goto('/1K%F6n16');
+	expect(response?.status()).toBeLessThan(400);
+	await expect(page.getByRole('heading', { level: 1 })).toContainText('Könige');
+});
+
+test('the homepage link clears the remembered chapter instead of bouncing back to it', async ({
+	page
+}) => {
+	await page.goto('/Joh3');
+	await expect(page).toHaveURL(/\/Joh3$/);
+
+	await page.getByRole('link', { name: 'Strongs.de – Startseite' }).click();
+
+	await expect(page).toHaveURL(/\/Joh1$/);
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -30,6 +30,12 @@ export const init: ServerInit = async () => {
  * protection by forgetting a check.
  */
 export const handle: Handle = async ({ event, resolve }) => {
+	const recovered = recoverMalformedUri(event.url);
+	// A plain Response rather than `redirect()`: thrown this early, before any `await`, it turns into
+	// an unhandled rejection instead of a redirect — `redirect()` further down (past the session
+	// lookup's `await`) is unaffected.
+	if (recovered) return new Response(null, { status: 301, headers: { location: recovered } });
+
 	const session = await resolveSession(getDb(), event.cookies);
 	event.locals.user = session?.user ?? null;
 	event.locals.sessionId = session?.sessionId ?? null;
@@ -54,3 +60,21 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	return response;
 };
+
+/**
+ * Some old browsers and stale bookmarked links percent-encode non-ASCII characters as Latin-1 (e.g.
+ * "ö" as `%F6`) instead of UTF-8 (`%C3%B6`). SvelteKit's router rejects that outright with a 400
+ * before any route runs, so it has to be recovered here: reinterpret the escapes as Latin-1 — whose
+ * codepoints (0–255) already agree with Unicode — and redirect to the correctly UTF-8-encoded URL.
+ */
+function recoverMalformedUri(url: URL): string | null {
+	try {
+		decodeURI(url.pathname);
+		return null;
+	} catch {
+		const recovered = url.pathname.replace(/%[0-9A-Fa-f]{2}/g, (hex) =>
+			String.fromCharCode(parseInt(hex.slice(1), 16))
+		);
+		return `${encodeURI(recovered)}${url.search}`;
+	}
+}

--- a/src/lib/components/SiteHeader.svelte
+++ b/src/lib/components/SiteHeader.svelte
@@ -60,6 +60,17 @@
 	}
 
 	/**
+	 * `/` on its own resumes the last chapter read, via a cookie — useful when typed directly, but it
+	 * means this link would otherwise just bounce a click straight back to wherever the reader already
+	 * is. Clearing the cookie first makes "Startseite" actually mean home; `data-sveltekit-preload-data
+	 * ="off"` on the link matters too, or hovering it would preload `/`'s data — reading the cookie —
+	 * before this handler ever runs, and the click would reuse that stale, already-fetched redirect.
+	 */
+	function goHome(): void {
+		document.cookie = 'location=; path=/; max-age=0; samesite=lax';
+	}
+
+	/**
 	 * Typing anywhere focuses the search box, as on the old site, and the arrow keys page through
 	 * chapters. Both are skipped while a field or a modifier key is in play.
 	 */
@@ -103,6 +114,8 @@
 	>
 		<a
 			href="/"
+			onclick={goHome}
+			data-sveltekit-preload-data="off"
 			class="group shrink-0 focus-visible:rounded-sm"
 			aria-label="Strongs.de – Startseite"
 		>

--- a/src/routes/[...reference]/+page.server.ts
+++ b/src/routes/[...reference]/+page.server.ts
@@ -60,7 +60,7 @@ import {
  *   3. anything else      → the search page
  */
 export async function load({ params, cookies, url, setHeaders, locals }) {
-	const raw = decodeURIComponent(params.reference ?? '').replace(/\/+$/, '');
+	const raw = decodeReferenceParam(params.reference ?? '').replace(/\/+$/, '');
 
 	// Legacy paths from the previous site: /async/Joh3 and /Joh3/trans/0_2/ variants.
 	const cleaned = raw.replace(/^async\//, '').replace(/\/?trans\/\d+_\d+$/, '');
@@ -368,6 +368,23 @@ export const actions = {
 		return { removed: true, listId: list.id };
 	}
 };
+
+/**
+ * Some old browsers and bookmarked links percent-encode non-ASCII characters as Latin-1 (e.g. "ö" as
+ * `%F6`) instead of UTF-8 (`%C3%B6`), which `decodeURIComponent` rejects as malformed and throws on —
+ * crashing the whole page instead of just failing to resolve a reference. Recovering the Latin-1
+ * reading handles that case; the codepoints it produces (0–255) already agree with Unicode, so German
+ * umlauts and similar characters round-trip correctly.
+ */
+function decodeReferenceParam(raw: string): string {
+	try {
+		return decodeURIComponent(raw);
+	} catch {
+		return raw.replace(/%[0-9A-Fa-f]{2}/g, (hex) =>
+			String.fromCharCode(parseInt(hex.slice(1), 16))
+		);
+	}
+}
 
 const LOCATION_COOKIE = 'location';
 


### PR DESCRIPTION
## Summary
- `/1K%F6n16` ("1Kön16" with "ö" mis-encoded as Latin-1 `%F6` instead of UTF-8 `%C3%B6" — something old browsers/stale bookmarks produce) threw a 400 before any route ran, because SvelteKit's router rejects a URI it can't decode. `hooks.server.ts` now detects that case up front, recovers the Latin-1 reading, and redirects to the correctly UTF-8-encoded URL. A narrower fallback in `[...reference]/+page.server.ts` also guards its own (pre-existing) `decodeURIComponent` call against a *different*, reachable crash: double-decoding an already-clean param that happens to contain a literal `%` (e.g. `/50%25` → `"50%"` → re-decoding throws).
- Separately: `/` resumes the last chapter read via a cookie. That's fine when typed directly, but it meant clicking the "Startseite" logo link just bounced you back to wherever you already were — including back to a broken reference. The link now clears that cookie on click so `/` actually lands on the default (John 1). Also had to disable the link's hover-preload (`data-sveltekit-preload-data="off"`), since SvelteKit prefetches `/`'s data on hover — before any click handler runs — and would otherwise reuse that stale, cookie-still-set redirect.

Addresses both remaining halves of the todo.md item about `https://strongs.de/1K%F6n16` and the Startseite link loop.

## Test plan
- [x] `pnpm test:unit`
- [x] `pnpm test:e2e` (two new tests: Latin-1-encoded reference doesn't crash and resolves to 1.Könige 16; clicking Startseite from a chapter goes to Joh1 instead of bouncing back)
- [x] `pnpm check` / `pnpm lint`