### PR TITLE
fix: format commentary text the same as scripture text

### DIFF
--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -3,8 +3,8 @@ import { expect, test, type Page } from '@playwright/test';
 /**
  * Reader, search and study sidebar.
  *
- * Runs against the fixture from `pnpm db:seed`: SEEDDE (with Strong's numbers) and SEEDPLAIN, plus
- * three dictionary entries.
+ * Runs against the fixture from `pnpm db:seed`: SEEDDE (with Strong's numbers), SEEDPLAIN and
+ * SEEDCOMMENTARY, plus three dictionary entries.
  */
 
 /**
@@ -16,6 +16,17 @@ async function useAlignedLayout(page: Page): Promise<void> {
 	await page
 		.context()
 		.addCookies([{ name: 'reader-layout', value: 'aligned', url: 'http://localhost:4173' }]);
+}
+
+/** The commentary fixture is not a default column, so tests exercising it must select it explicitly. */
+async function useCommentaryColumn(page: Page): Promise<void> {
+	await page.context().addCookies([
+		{
+			name: 'columns',
+			value: 'SEEDDE,SEEDPLAIN,SEEDCOMMENTARY',
+			url: 'http://localhost:4173'
+		}
+	]);
 }
 
 test('the root redirects into the reader', async ({ page }) => {
@@ -39,6 +50,65 @@ test('a reference shows the chapter in parallel columns', async ({ page }) => {
 
 	// The requested verse is highlighted.
 	await expect(page.locator('.verse.highlighted').first()).toBeVisible();
+});
+
+test('commentary text is formatted the same as scripture text, in both layouts', async ({
+	page
+}) => {
+	await useCommentaryColumn(page);
+
+	await page.goto('/Joh3,16');
+	const flowCommentary = page.locator('.flow-reference .commentary-body').first();
+	await expect(flowCommentary).toContainText('bekannteste Vers');
+	expect(
+		await page
+			.locator('.flow-reference')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontSize)
+	).toBe(
+		await page
+			.locator('.flow-verse')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontSize)
+	);
+	expect(
+		await page
+			.locator('.flow-reference')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontFamily)
+	).toBe(
+		await page
+			.locator('.flow-verse')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontFamily)
+	);
+
+	await useAlignedLayout(page);
+	await page.goto('/Joh3,16');
+	const alignedCommentary = page.locator('.reference-cell .commentary-body').first();
+	await expect(alignedCommentary).toContainText('bekannteste Vers');
+	expect(
+		await page
+			.locator('.reference-cell')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontSize)
+	).toBe(
+		await page
+			.locator('.verse')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontSize)
+	);
+	expect(
+		await page
+			.locator('.reference-cell')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontFamily)
+	).toBe(
+		await page
+			.locator('.verse')
+			.first()
+			.evaluate((el) => getComputedStyle(el).fontFamily)
+	);
 });
 
 test('verses stay aligned across columns', async ({ page }) => {
@@ -264,8 +334,10 @@ test('a reference typed into the search box goes to the chapter', async ({ page 
 test('the column selection persists across navigations', async ({ page }) => {
 	await page.goto('/Joh3');
 
-	// Put the second translation in the first column.
+	// Put the second translation in the first column. The fixture now spans more than one resource
+	// kind (bibles and a commentary), so the menu groups them under an expandable "Bibeln" submenu.
 	await page.locator('#column-0').click();
+	await page.getByRole('menuitem', { name: 'Bibeln' }).click();
 	await page
 		.locator('form[action="?/setColumn"]')
 		.filter({ has: page.locator('input[name="resource"][value="SEEDPLAIN"]') })
@@ -289,7 +361,8 @@ test('a closed column can be opened again', async ({ page }) => {
 	await expect(page.locator('button[id^="column-"]')).toHaveCount(1);
 
 	await page.getByRole('button', { name: 'Spalte hinzufügen' }).first().click();
-	await page.getByRole('menuitem').first().click();
+	await page.getByRole('menuitem', { name: 'Bibeln' }).click();
+	await page.locator('form[action="?/addColumn"]').getByRole('menuitem').first().click();
 
 	await expect(page.locator('button[id^="column-"]')).toHaveCount(2);
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -13,10 +13,12 @@ import { eq } from 'drizzle-orm';
 import { parseVpl } from '../src/lib/bible/parse/vpl.ts';
 import { parseZefania } from '../src/lib/bible/parse/zefania.ts';
 import { parseStrongsXml } from '../src/lib/bible/parse/strongs-xml.ts';
+import { parseCommentaryCsv } from '../src/lib/bible/parse/commentary.ts';
 import { createDb } from '../src/lib/server/db/client.ts';
 import { refreshStrongStatisticsBlocking } from '../src/lib/server/db/statistics.ts';
 import { ingestBible } from '../src/lib/server/import/ingest-bible.ts';
 import { ingestLexicon } from '../src/lib/server/import/ingest-lexicon.ts';
+import { ingestCommentary } from '../src/lib/server/import/ingest-simple.ts';
 import { hashPassword } from '../src/lib/server/auth/password.ts';
 import { resources, users } from '../src/lib/server/db/schema.ts';
 
@@ -77,6 +79,10 @@ const LEXICON = `<?xml version="1.0" encoding="utf-8"?>
 	</entry>
 </entries></strongsdictionary>`;
 
+/** A commentary entry on the same verse as the fixture translations, so the reader has something to
+ *  show alongside them. */
+const COMMENTARY = `Joh 3,16\tDer bekannteste Vers der Bibel. **Also** meint hier: auf diese Weise.`;
+
 const url = process.env.DATABASE_URL;
 if (!url) {
 	console.error('DATABASE_URL is not set');
@@ -95,9 +101,15 @@ try {
 
 	await ingestLexicon(db, parseStrongsXml(LEXICON), { sourceFormat: 'strongs-xml' });
 
+	await ingestCommentary(db, parseCommentaryCsv(COMMENTARY), {
+		sourceFormat: 'commentary-csv',
+		overrides: { id: 'SEEDCOMMENTARY', name: 'Testkommentar', abbrev: 'Kommentar' }
+	});
+
 	// Deterministic column order, so the end-to-end tests can rely on which column is which.
 	await db.update(resources).set({ sortOrder: 10 }).where(eq(resources.id, 'SEEDDE'));
 	await db.update(resources).set({ sortOrder: 20 }).where(eq(resources.id, 'SEEDPLAIN'));
+	await db.update(resources).set({ sortOrder: 30 }).where(eq(resources.id, 'SEEDCOMMENTARY'));
 
 	await refreshStrongStatisticsBlocking(db);
 
@@ -116,7 +128,7 @@ try {
 		});
 	}
 
-	console.log('seeded: SEEDDE, SEEDPLAIN, STRONGS_GREEK and the admin account');
+	console.log('seeded: SEEDDE, SEEDPLAIN, SEEDCOMMENTARY, STRONGS_GREEK and the admin account');
 } catch (error) {
 	console.error('seeding failed:', error);
 	process.exitCode = 1;

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -1419,8 +1419,9 @@
 		   when an entry is shorter than the number's own line height. */
 		display: flow-root;
 		margin-bottom: 1rem;
-		font-size: 0.875rem;
-		line-height: 1.6;
+		font-family: var(--font-serif);
+		font-size: calc(1.19rem * var(--reader-font-scale, 1));
+		line-height: 1.72;
 	}
 
 	.flow-note {
@@ -1454,8 +1455,9 @@
 		min-width: 0;
 		padding: 0.45rem 0.75rem 0.8rem;
 		border-right: 1px solid var(--color-stone-100);
-		font-size: 0.875rem;
-		line-height: 1.6;
+		font-family: var(--font-serif);
+		font-size: calc(1.19rem * var(--reader-font-scale, 1));
+		line-height: 1.72;
 	}
 
 	:global(.dark) .reference-cell {


### PR DESCRIPTION
## Summary
- `.reference-cell`/`.flow-reference` (commentary cells, both the aligned-columns and flowing-text reader layouts) hard-coded `font-size: 0.875rem` with no `font-family`, falling back to the sans body font — versus `.verse`/`.flow-verse` (scripture cells) at `calc(1.19rem * var(--reader-font-scale, 1))` in the serif font. Commentary is now sized/faced identically (and picks up the reader's font-scale preference too).
- Added a commentary resource (`SEEDCOMMENTARY`) to the e2e fixture (`scripts/seed.ts`) so this has real coverage. That in turn exposed that the column-picker menu (`ResourceMenuItems.svelte`) groups resources by kind under an expandable "Bibeln"/"Kommentare" submenu once more than one kind exists — previously untested, since the fixture only ever had bibles. Updated the two existing column-picker tests to expand the "Bibeln" group first, matching what a real visitor now sees with a Bible and a commentary both installed.

Addresses the todo.md item: "Kommentartext sollte ebenso formatiert sein wie der Bibeltext. Kommentartext ist momentan kleiner."

## Test plan
- [x] `pnpm test:unit`
- [x] `pnpm test:e2e` (new test asserts matching `font-size`/`font-family` between commentary and scripture cells in both layouts; two pre-existing column-picker tests updated for the new grouped submenu)
- [x] `pnpm check` / `pnpm lint`