### PR TITLE
Fix commentary verse ranges, headings, and range-aware scroll sync

### DIFF
--- a/src/lib/bible/parse/commentary.ts
+++ b/src/lib/bible/parse/commentary.ts
@@ -91,18 +91,34 @@ export async function* parseCommentaryThml(input: SourceInput): ParseStream {
 	let entries = 0;
 	let title: string | undefined;
 
-	/** Reference of the section being read, and the HTML collected for it. */
+	/** Reference of the section being read, its heading (if any), and the HTML collected for it. */
 	let reference: ReturnType<typeof parseReference> | null = null;
+	let sectionTitle: string | undefined;
+	/**
+	 * A CCEL section heading lives on the `<div title="…">` that wraps the `scripRef`/`scripCom`
+	 * marker, e.g. `<div class="Section" title="Commentary on John 3:16">` — captured here as soon as
+	 * that div opens, then claimed by the section the very next reference marker starts.
+	 */
+	let pendingDivTitle: string | undefined;
 	let body = '';
 	let depth = 0;
 	let inTitle = false;
 
 	const flush = ():
-		| { book: number; chapter: number; verseStart?: number; verseEnd?: number; bodyHtml: string }
+		| {
+				book: number;
+				chapter: number;
+				verseStart?: number;
+				verseEnd?: number;
+				title?: string;
+				bodyHtml: string;
+		  }
 		| undefined => {
 		const text = sanitizeHtml(body);
 		const current = reference;
+		const currentTitle = sectionTitle;
 		reference = null;
+		sectionTitle = undefined;
 		body = '';
 		if (!current || !text) return undefined;
 
@@ -111,12 +127,16 @@ export async function* parseCommentaryThml(input: SourceInput): ParseStream {
 			chapter: current.chapter,
 			...(current.verse !== undefined ? { verseStart: current.verse } : {}),
 			...(current.verseEnd !== undefined ? { verseEnd: current.verseEnd } : {}),
+			...(currentTitle ? { title: currentTitle } : {}),
 			bodyHtml: text
 		};
 	};
 
 	for await (const event of readXml(input)) {
 		if (event.type === 'open') {
+			const divTitle = attribute(event.attributes, 'title');
+			if (divTitle) pendingDivTitle = divTitle;
+
 			if (event.name === 'scripref' || event.name === 'scripcom') {
 				// A reference marker starts a new section; the previous one is complete.
 				const passage = attribute(event.attributes, 'passage', 'parsed', 'value');
@@ -126,6 +146,8 @@ export async function* parseCommentaryThml(input: SourceInput): ParseStream {
 					yield { type: 'commentaryEntry', entry: pending };
 				}
 				reference = passage ? parseReference(normalizePassage(passage)) : null;
+				sectionTitle = pendingDivTitle;
+				pendingDivTitle = undefined;
 				if (passage && !reference) {
 					yield { type: 'warning', message: `unreadable passage reference "${passage}"` };
 				}

--- a/src/lib/bible/parse/formats.spec.ts
+++ b/src/lib/bible/parse/formats.spec.ts
@@ -7,7 +7,12 @@ import { parseUsfx, parseUsx } from './usx.ts';
 import { parseVpl } from './vpl.ts';
 import { parseTsk } from './tsk.ts';
 import { parseTsp } from './tsp.ts';
-import { parseCommentaryCsv, parseZefaniaCommentary, sanitizeHtml } from './commentary.ts';
+import {
+	parseCommentaryCsv,
+	parseCommentaryThml,
+	parseZefaniaCommentary,
+	sanitizeHtml
+} from './commentary.ts';
 import type {
 	ParsedCommentaryEntry,
 	ParsedCrossReference,
@@ -412,6 +417,41 @@ Röm 8,28-30\tNicht alles ist gut, aber Gott wirkt in allem.
 			bodyHtml: 'Der bekannteste Vers. <strong>Also</strong> meint: auf diese Weise.'
 		});
 		expect(commentary[1]).toMatchObject({ book: 45, chapter: 8, verseStart: 28, verseEnd: 30 });
+	});
+
+	it('reads a per-section heading from a ThML section div', async () => {
+		const { commentary, metadata } = await drain(
+			parseCommentaryThml(`<ThML>
+				<ThML.head><title>Ausgewählte Kommentare</title></ThML.head>
+				<ThML.body>
+					<div class="Section" title="Kommentar zu Johannes 3:16">
+						<scripRef passage="John 3:16"/>Der bekannteste Vers der Bibel.
+					</div>
+					<div class="Section" title="Kommentar zu Römer 8:28-30">
+						<scripCom passage="Romans 8:28-30"/>Alles wirkt zum Guten.
+					</div>
+				</ThML.body>
+			</ThML>`)
+		);
+
+		expect(metadata).toMatchObject({ name: 'Ausgewählte Kommentare' });
+		expect(commentary).toMatchObject([
+			{
+				book: 43,
+				chapter: 3,
+				verseStart: 16,
+				title: 'Kommentar zu Johannes 3:16',
+				bodyHtml: 'Der bekannteste Vers der Bibel.'
+			},
+			{
+				book: 45,
+				chapter: 8,
+				verseStart: 28,
+				verseEnd: 30,
+				title: 'Kommentar zu Römer 8:28-30',
+				bodyHtml: 'Alles wirkt zum Guten.'
+			}
+		]);
 	});
 });
 

--- a/src/lib/server/import/sword.spec.ts
+++ b/src/lib/server/import/sword.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseDiathekeOutput } from './sword.ts';
+import { extractTitle, parseDiathekeOutput, swordCommentaryEntries } from './sword.ts';
 
 describe('SWORD adapter', () => {
 	it('finds references after SWORD section headings and joins continuation lines', () => {
@@ -24,6 +24,124 @@ describe('SWORD adapter', () => {
 	it('recognises book names that contain a number', () => {
 		expect([...parseDiathekeOutput('1 Samuel 3:10: Rede, denn dein Knecht hört.')]).toEqual([
 			{ book: 9, chapter: 3, verse: 10, content: 'Rede, denn dein Knecht hört.' }
+		]);
+	});
+});
+
+describe('extractTitle', () => {
+	it('isolates a heading merged in front of the body', () => {
+		expect(
+			extractTitle(
+				'Der erste Tag Mitten in die Dunkelheit hinein ertönt eine mächtige Stimme.',
+				'Mitten in die Dunkelheit hinein ertönt eine mächtige Stimme.'
+			)
+		).toBe('Der erste Tag');
+	});
+
+	it('finds no heading when both readings are identical', () => {
+		expect(extractTitle('Mitten in die Dunkelheit.', 'Mitten in die Dunkelheit.')).toBeUndefined();
+	});
+
+	it('gives up when the heading is not a single leading chunk', () => {
+		// A book/testament introduction can bundle several unrelated headings through the body, not just
+		// at the front — the "without heading" reading is then not a trailing match of the "with heading"
+		// one, so there is no single heading to isolate.
+		expect(
+			extractTitle(
+				'Einleitung Das Ziel der Kommentare. Der Autor. Copyright.',
+				'Das Ziel der Kommentare. Autor.'
+			)
+		).toBeUndefined();
+	});
+});
+
+describe('swordCommentaryEntries', () => {
+	it('merges consecutive verses with identical content into one ranged entry with its heading', () => {
+		const withHeadings = [
+			'Genesis 1:3: Der erste Tag Mitten in die Dunkelheit.',
+			'Genesis 1:4: Der erste Tag Mitten in die Dunkelheit.',
+			'Genesis 1:5: Der erste Tag Mitten in die Dunkelheit.',
+			'Genesis 1:6: Der zweite Tag Durch das Licht.'
+		].join('\n');
+		const withoutHeadings = [
+			'Genesis 1:3: Mitten in die Dunkelheit.',
+			'Genesis 1:4: Mitten in die Dunkelheit.',
+			'Genesis 1:5: Mitten in die Dunkelheit.',
+			'Genesis 1:6: Durch das Licht.'
+		].join('\n');
+
+		expect([...swordCommentaryEntries(withHeadings, withoutHeadings)]).toEqual([
+			{
+				book: 1,
+				chapter: 1,
+				verseStart: 3,
+				verseEnd: 5,
+				title: 'Der erste Tag',
+				bodyHtml: 'Mitten in die Dunkelheit.'
+			},
+			{
+				book: 1,
+				chapter: 1,
+				verseStart: 6,
+				verseEnd: 6,
+				title: 'Der zweite Tag',
+				bodyHtml: 'Durch das Licht.'
+			}
+		]);
+	});
+
+	it('does not merge across a chapter boundary even when the content matches', () => {
+		const withHeadings = [
+			'Genesis 1:31: Schluss Und es war sehr gut.',
+			'Genesis 2:1: Schluss Und es war sehr gut.'
+		].join('\n');
+		const withoutHeadings = [
+			'Genesis 1:31: Und es war sehr gut.',
+			'Genesis 2:1: Und es war sehr gut.'
+		].join('\n');
+
+		expect([...swordCommentaryEntries(withHeadings, withoutHeadings)]).toEqual([
+			{
+				book: 1,
+				chapter: 1,
+				verseStart: 31,
+				verseEnd: 31,
+				title: 'Schluss',
+				bodyHtml: 'Und es war sehr gut.'
+			},
+			{
+				book: 1,
+				chapter: 2,
+				verseStart: 1,
+				verseEnd: 1,
+				title: 'Schluss',
+				bodyHtml: 'Und es war sehr gut.'
+			}
+		]);
+	});
+
+	it('keeps a single verse as its own entry when neighbouring content differs', () => {
+		const withHeadings = 'Genesis 1:1: Einleitung Am Anfang schuf Gott.';
+		const withoutHeadings = 'Genesis 1:1: Am Anfang schuf Gott.';
+
+		expect([...swordCommentaryEntries(withHeadings, withoutHeadings)]).toEqual([
+			{
+				book: 1,
+				chapter: 1,
+				verseStart: 1,
+				verseEnd: 1,
+				title: 'Einleitung',
+				bodyHtml: 'Am Anfang schuf Gott.'
+			}
+		]);
+	});
+
+	it('falls back to the heading-included text with no title when the two readings do not line up verse for verse', () => {
+		const withHeadings = 'Genesis 1:1: Einleitung Am Anfang.';
+		const withoutHeadings = 'Genesis 1:1: Am Anfang.\nGenesis 1:2: Die Erde war wüst.';
+
+		expect([...swordCommentaryEntries(withHeadings, withoutHeadings)]).toEqual([
+			{ book: 1, chapter: 1, verseStart: 1, verseEnd: 1, bodyHtml: 'Einleitung Am Anfang.' }
 		]);
 	});
 });

--- a/src/lib/server/import/sword.ts
+++ b/src/lib/server/import/sword.ts
@@ -82,13 +82,23 @@ export async function* readSwordModule(
 
 		let count = 0;
 		for (const book of BOOKS) {
-			const result = await run(
-				'diatheke',
-				['-b', configuration.module, '-o', 'nfmhs', '-f', 'OSIS', '-e', 'UTF8', '-k', book.osisId],
-				environment
-			);
-
 			if (expectedFormat === 'sword-bible') {
+				const result = await run(
+					'diatheke',
+					[
+						'-b',
+						configuration.module,
+						'-o',
+						'nfmhs',
+						'-f',
+						'OSIS',
+						'-e',
+						'UTF8',
+						'-k',
+						book.osisId
+					],
+					environment
+				);
 				const document = swordBookAsOsis(result.stdout, book.id, book.osisId);
 				if (document) {
 					for await (const event of parseOsis(document)) {
@@ -99,7 +109,45 @@ export async function* readSwordModule(
 					}
 				}
 			} else {
-				for (const entry of swordCommentaryEntries(result.stdout)) {
+				// Read the book twice, with and without diatheke's section-heading filter ("h" in `-o`).
+				// A commentary section's heading has no other structural marker in diatheke's flattened
+				// OSIS output — it is plain text merged straight into the body — so the only way to tell
+				// the two apart is to diff a rendering that has it against one that does not.
+				const [withHeadings, withoutHeadings] = await Promise.all([
+					run(
+						'diatheke',
+						[
+							'-b',
+							configuration.module,
+							'-o',
+							'nfmhs',
+							'-f',
+							'OSIS',
+							'-e',
+							'UTF8',
+							'-k',
+							book.osisId
+						],
+						environment
+					),
+					run(
+						'diatheke',
+						[
+							'-b',
+							configuration.module,
+							'-o',
+							'nfms',
+							'-f',
+							'OSIS',
+							'-e',
+							'UTF8',
+							'-k',
+							book.osisId
+						],
+						environment
+					)
+				]);
+				for (const entry of swordCommentaryEntries(withHeadings.stdout, withoutHeadings.stdout)) {
 					count += 1;
 					yield { type: 'commentaryEntry', entry };
 				}
@@ -135,18 +183,112 @@ function swordBookAsOsis(output: string, expectedBook: number, osisId: string): 
 	return `<osis><osisText osisIDWork="SWORD"><div type="book" osisID="${osisId}">${verses.join('')}</div></osisText></osis>`;
 }
 
-function* swordCommentaryEntries(output: string) {
-	for (const parsed of parseDiathekeOutput(output)) {
-		const bodyHtml = sanitizeHtml(parsed.content);
-		if (!bodyHtml) continue;
-		yield {
-			book: parsed.book,
-			chapter: parsed.chapter,
-			verseStart: parsed.verse,
-			verseEnd: parsed.verse,
-			bodyHtml
+type CommentarySection = {
+	book: number;
+	chapter: number;
+	verseStart: number;
+	verseEnd: number;
+	title?: string;
+	bodyHtml: string;
+};
+
+/**
+ * Turns diatheke's per-verse commentary text into per-section entries.
+ *
+ * A SWORD zCom module stores one block of text per commented section (often several verses, e.g.
+ * `annotateRef="Gen.1.3-Gen.1.5"`) and maps every verse in that range to the same block. Asking
+ * diatheke for each verse individually therefore returns byte-identical text for every verse in a
+ * section — which is exactly how the section's range is recovered here: consecutive verses of the same
+ * chapter with identical rendered content are merged back into one entry spanning `verseStart..verseEnd`,
+ * rather than imported as repeated, single-verse duplicates.
+ *
+ * `withHeadings`/`withoutHeadings` are the same book read twice, with diatheke's section-heading filter
+ * ("h" in `-o`) toggled. See `extractTitle` for why both are needed to recover the heading text.
+ */
+export function* swordCommentaryEntries(
+	withHeadings: string,
+	withoutHeadings: string
+): Generator<CommentarySection> {
+	const headed = [...parseDiathekeOutput(withHeadings)];
+	const plain = [...parseDiathekeOutput(withoutHeadings)];
+	const alignedPlain =
+		headed.length === plain.length &&
+		headed.every(
+			(entry, index) =>
+				entry.book === plain[index]!.book &&
+				entry.chapter === plain[index]!.chapter &&
+				entry.verse === plain[index]!.verse
+		);
+
+	type PendingSection = {
+		book: number;
+		chapter: number;
+		verseStart: number;
+		verseEnd: number;
+		title: string | undefined;
+		plainContent: string;
+	};
+	let pending: PendingSection | null = null;
+
+	function* flush(): Generator<CommentarySection> {
+		if (!pending) return;
+		const bodyHtml = sanitizeHtml(pending.plainContent);
+		if (bodyHtml) {
+			yield {
+				book: pending.book,
+				chapter: pending.chapter,
+				verseStart: pending.verseStart,
+				verseEnd: pending.verseEnd,
+				...(pending.title ? { title: pending.title } : {}),
+				bodyHtml
+			};
+		}
+	}
+
+	for (const [index, verse] of headed.entries()) {
+		const plainContent = alignedPlain ? plain[index]!.content : verse.content;
+
+		if (
+			pending &&
+			pending.book === verse.book &&
+			pending.chapter === verse.chapter &&
+			pending.verseEnd + 1 === verse.verse &&
+			pending.plainContent === plainContent
+		) {
+			pending.verseEnd = verse.verse;
+			continue;
+		}
+
+		yield* flush();
+		pending = {
+			book: verse.book,
+			chapter: verse.chapter,
+			verseStart: verse.verse,
+			verseEnd: verse.verse,
+			title: alignedPlain ? extractTitle(verse.content, plainContent) : undefined,
+			plainContent
 		};
 	}
+	yield* flush();
+}
+
+/**
+ * Recovers a section's heading by diffing the same text rendered with and without diatheke's
+ * section-heading filter. The filter has no output of its own for the heading (no tag, no delimiter) —
+ * it either merges the heading straight into the body as plain text, or drops it entirely — so the
+ * heading can only be isolated as whatever leading text disappears when the filter is turned off.
+ *
+ * This only recovers a clean, single heading: a book/testament introduction can bundle several
+ * unrelated headings into one block (e.g. "Einleitung Downloads Über den Autor …"), which does not
+ * reduce to "one heading, then the body" — `withoutHeading` is then not a clean trailing match and no
+ * title is extracted, leaving that block's text exactly as before.
+ */
+export function extractTitle(withHeading: string, withoutHeading: string): string | undefined {
+	const headed = withHeading.trim();
+	const body = withoutHeading.trim();
+	if (body.length === 0 || headed.length <= body.length || !headed.endsWith(body)) return undefined;
+	const title = headed.slice(0, headed.length - body.length).trim();
+	return title || undefined;
 }
 
 function parseDiathekeLine(line: string) {

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -287,6 +287,14 @@
 	let suppressFlowTimer: ReturnType<typeof setTimeout> | undefined;
 	let suppressReaderScroll = false;
 	let flowSyncTimer: ReturnType<typeof setTimeout> | undefined;
+	/**
+	 * The element each flow column was last aligned to, indexed by column. A ranged block (a comment
+	 * spanning several verses, or a merged Bible cell) should hold still while the reader is anywhere
+	 * inside its range — only actually re-aligning a column when its covering block *changes* achieves
+	 * that: scrolling within the same range keeps finding the same element here and is a no-op, and only
+	 * crossing into the next range's block triggers the single jump that brings it to the anchor line.
+	 */
+	let lastAlignedElement: (Element | null)[] = [];
 	const visibleStreamChapter = $derived(
 		streamChapters.find(
 			(stream) => `${stream.reference.book}:${stream.reference.chapter}` === visibleChapterKey
@@ -496,6 +504,31 @@
 	}
 
 	/**
+	 * Finds the element for a verse within a flow column, matching a ranged block (a commentary entry or
+	 * a merged Bible verse cell) whenever the verse falls inside its `data-verse-key`/`data-verse-end`
+	 * span, not just on an exact key match. Without this, a comment covering verses 3-5 (or a translation
+	 * that prints 16-17 as one unit) is only found while the anchor verse is exactly its first verse —
+	 * everywhere else in the range, sync silently does nothing and a deep link into the middle of the
+	 * range finds no target to scroll to at all.
+	 */
+	function findVerseElement(container: Element, key: string, verse: number): HTMLElement | null {
+		const exact = container.querySelector<HTMLElement>(`[data-verse-key="${key}"]`);
+		if (exact) return exact;
+
+		const prefix = key.slice(0, key.lastIndexOf(':') + 1);
+		for (const candidate of container.querySelectorAll<HTMLElement>('[data-verse-end]')) {
+			const candidateKey = candidate.dataset.verseKey;
+			if (!candidateKey || !candidateKey.startsWith(prefix)) continue;
+			const start = Number(candidateKey.slice(prefix.length));
+			const end = Number(candidate.dataset.verseEnd);
+			if (Number.isFinite(start) && Number.isFinite(end) && start <= verse && verse <= end) {
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Scrolls straight to a reference already in the loaded stream, without a navigation — used both to
 	 * land on a deep-linked verse after a real navigation and, via `jumpToVerse`, to let the header's
 	 * search field re-centre on a reference that a plain `goto` would treat as a no-op because the URL
@@ -513,14 +546,15 @@
 		const key = `${book}:${chapter}:${verse}`;
 		if (data.readerLayout === 'flow') {
 			let found = false;
-			for (const column of flowColumns) {
+			for (const [index, column] of flowColumns.entries()) {
 				const target =
-					column?.querySelector<HTMLElement>(`[data-verse-key="${key}"]`) ??
+					(column && findVerseElement(column, key, verse)) ??
 					(allowHighlightedFallback
 						? column?.querySelector<HTMLElement>('.flow-verse.highlighted')
 						: null);
 				if (column && target) {
 					found = true;
+					lastAlignedElement[index] = target;
 					const next =
 						column.scrollTop +
 						target.getBoundingClientRect().top -
@@ -570,21 +604,26 @@
 		const anchor = verses.find((verse) => verse.getBoundingClientRect().bottom > sourceTop);
 		if (!anchor?.dataset.verseKey) return;
 		if (trackAddress) scheduleAddressBarUpdate(anchor.dataset.verseKey);
-		const sourceAnchorOffset = anchor.getBoundingClientRect().top - sourceTop;
+		const anchorVerse = Number(anchor.dataset.verseKey.split(':').at(-1));
 
 		for (let index = 0; index < flowColumns.length; index += 1) {
 			if (index === sourceIndex) continue;
 			const column = flowColumns[index];
-			const target = column?.querySelector<HTMLElement>(
-				`[data-verse-key="${anchor.dataset.verseKey}"]`
-			);
-			if (column && target) {
-				const columnTop = column.getBoundingClientRect().top + anchorInset;
-				const next =
-					column.scrollTop + target.getBoundingClientRect().top - columnTop - sourceAnchorOffset;
-				suppressProgrammaticFlowScroll();
-				column.scrollTop = next;
-			}
+			const target = column && findVerseElement(column, anchor.dataset.verseKey, anchorVerse);
+			if (!column || !target) continue;
+
+			// Only a genuine change of the block covering the anchor verse moves this column — as long as
+			// scrolling the source stays within the same ranged block (e.g. a comment on verses 3-5), the
+			// same element keeps being found here and nothing happens. That is what lets a long comment be
+			// read on its own without dragging the Bible text along, and vice versa: the target only jumps
+			// once the reader actually crosses into the next range.
+			if (lastAlignedElement[index] === target) continue;
+			lastAlignedElement[index] = target;
+
+			const columnTop = column.getBoundingClientRect().top + anchorInset;
+			const next = column.scrollTop + target.getBoundingClientRect().top - columnTop;
+			suppressProgrammaticFlowScroll();
+			column.scrollTop = next;
 		}
 	}
 
@@ -894,6 +933,7 @@
 											<p
 												class="flow-verse"
 												data-verse-key={`${stream.reference.book}:${stream.reference.chapter}:${cell.verse}`}
+												data-verse-end={cell.verseEnd ?? cell.verse}
 												id={columnIndex === 0
 													? `${stream.shortBookName}${stream.reference.chapter}_${cell.verse}`
 													: undefined}
@@ -987,11 +1027,17 @@
 												row.verse
 											)}
 											{#if entries.length}
+												{@const rangeEnd = Math.max(
+													...entries.map((entry) => entry.verseEnd ?? entry.verseStart ?? row.verse)
+												)}
 												<article
 													class="flow-reference"
 													data-verse-key={`${stream.reference.book}:${stream.reference.chapter}:${row.verse}`}
+													data-verse-end={rangeEnd}
 												>
-													<span class="verse-number">{row.verse}</span>
+													<span class="verse-number"
+														>{row.verse}{#if rangeEnd > row.verse}-{rangeEnd}{/if}</span
+													>
 													{#each entries as entry (entry.id)}
 														{#if entry.title}<h3 class="commentary-title">{entry.title}</h3>{/if}
 														<!-- Imported commentary is reduced to an allow-list by its parser. -->
@@ -1208,12 +1254,18 @@
 											row.verse
 										)}
 										{#if entries.length > 0}
+											{@const rangeEnd = Math.max(
+												...entries.map((entry) => entry.verseEnd ?? entry.verseStart ?? row.verse)
+											)}
 											<article
 												class="reference-cell"
 												class:hidden-on-mobile={columnIndex !== mobileColumn}
-												style="grid-column: {columnIndex + 1}; grid-row: {rowIndex * 2 + 2}"
+												style="grid-column: {columnIndex + 1}; grid-row: {rowIndex * 2 +
+													2} / span {(rangeEnd - row.verse + 1) * 2 - 1}"
 											>
-												<span class="verse-number">{row.verse}</span>
+												<span class="verse-number"
+													>{row.verse}{#if rangeEnd > row.verse}-{rangeEnd}{/if}</span
+												>
 												{#each entries as entry (entry.id)}
 													{#if entry.title}
 														<h3 class="commentary-title">{entry.title}</h3>


### PR DESCRIPTION
## Summary
- SWORD zCom commentary imports (e.g. GerKingComments) imported every verse in a commented range as a separate, duplicated entry with no heading, because `swordCommentaryEntries` hard-coded `verseStart === verseEnd`. It now merges consecutive verses with byte-identical diatheke output back into one ranged entry, and recovers the section heading by diffing the same book read with/without diatheke's section-heading filter (the heading has no other marker in diatheke's flattened output).
- The reader ignored `verseEnd` for commentary entirely: no grid span in the aligned layout, no verse-range label, and flow-layout scroll sync matched columns by exact verse key only — a multi-verse comment held its position only by accident and was never found at all for a deep link into the middle of its range.
- Flow-layout sync now tracks which block each column was last aligned to and only moves a column when that actually changes, so a comment spanning several verses holds still while it's being read, in both directions (Bible → comment and comment → Bible), and jumps exactly at the next range boundary.
- ThML commentary sections now also read a per-section heading from a `<div title="…">` wrapper, not just the document-level title.

## Test plan
- [x] `pnpm test:unit` (258 tests)
- [x] `pnpm test:e2e` (61 tests)
- [x] `pnpm run lint` / `pnpm run check`
- [x] Imported the real GerKingComments SWORD module (via a `diatheke`-enabled Docker container) against a local Postgres and verified Gen 1 in the reader: correct ranges/titles (e.g. "3-5 Der erste Tag"), no duplicated text, and range-locked scroll sync in the flow layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)