### PR TITLE
Fix permission denied writing backups after deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,18 @@ COPY --from=build --chown=node:node /app/drizzle ./drizzle
 COPY --from=build --chown=node:node /app/scripts/migrate.ts ./scripts/migrate.ts
 COPY --from=build --chown=node:node /app/package.json ./package.json
 
-USER node
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
+# No USER here: the container starts as root so it can fix ownership of the mounted volumes, then
+# drops to the unprivileged `node` user before running anything from the image. This matters for
+# `backups` specifically — that volume is reused from the old backup sidecar (see compose.yaml),
+# which wrote to it as a different user, so a fresh deploy inherits a directory `node` cannot write
+# to until this runs. `chown` on the directories themselves is enough (not `-R`): creating or
+# deleting entries only needs write access to the containing directory, not ownership of the files
+# already in it. `setpriv` execs directly into the target process — no wrapper left as PID 1 — so
+# this changes nothing about how the server receives signals once it is running.
 # Migrations run in the entrypoint rather than at image build time: they need the live database.
-CMD ["sh", "-c", "node scripts/migrate.ts && node build/index.js"]
+CMD ["sh", "-c", "chown node:node /app/var/uploads /app/var/backups && exec setpriv --reuid=node --regid=node --init-groups sh -c 'node scripts/migrate.ts && exec node build/index.js'"]


### PR DESCRIPTION
## Summary
Fixes the `pg_dump: error: could not open output file "/app/var/backups/download-....dump": Permission denied` error reported after deploying #98.

**Root cause:** `compose.yaml` intentionally reuses the `backups` Docker volume from the old `prodrigestivill/postgres-backup-local` sidecar (so its existing dumps survive the migration to the in-app feature). That volume is left owned by whatever user the old sidecar image ran as, not by this app's `node` user (uid 1000). On deploy, the container inherited a directory it couldn't write to, so every backup/download failed immediately.

**Fix:** the container now starts as root, `chown`s the two mount points (`/app/var/uploads`, `/app/var/backups`) — not recursively, since only directory-level write access is needed to create or prune entries, existing files' ownership doesn't matter — and drops to the `node` user via `setpriv` (already present in the base image, part of `util-linux`) before running migrations and the server. `setpriv` execs directly into the target process, so the running server is still PID 1 as `node`, same as before; no new dependency, no wrapper process, no change to signal handling.

## Test plan
- [x] Reproduced the exact reported error: seeded a Docker volume with root ownership (simulating the reused old sidecar volume) and confirmed `pg_dump` fails with `Permission denied` under the previous Dockerfile.
- [x] Confirmed the fix resolves it: same simulated volume, new Dockerfile — write succeeds.
- [x] Confirmed the running server process is still `uid=1000` (`node`), not root, by inspecting `/proc/1/status` in a live container.
- [x] Confirmed pre-existing files from the old sidecar in the volume are left untouched (non-recursive chown).
- [x] Full container boot verified against a live Postgres: migrations apply, `/healthz` returns ok.
- [x] `pnpm lint` / `pnpm check` — clean
- [x] `pnpm test:unit` — 322 passed
- [x] `pnpm test:e2e` — 66 passed / 1 skipped (unrelated to this change, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)