### PR TITLE
Fix reader scroll-jump bug, add column resize, flow-sync toggle, and accessible tabs

### DIFF
--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -636,6 +636,55 @@ test('on a phone the study panel is a sheet that leaves the verse visible', asyn
 	expect(verseBox.y).toBeLessThan(sheetBox.y);
 });
 
+test('the mobile column switcher exposes real tab semantics without hiding desktop columns', async ({
+	page
+}) => {
+	// Default (desktop) viewport first: the regression this specifically guards against is
+	// `aria-hidden` leaking onto desktop, where every column is visible at once regardless of which
+	// one `mobileColumn` happens to name.
+	await page.goto('/Joh3');
+
+	const columns = page.locator('.flow-column');
+	await expect(columns).toHaveCount(2);
+	await expect(columns.first()).not.toHaveAttribute('aria-hidden', 'true');
+	await expect(columns.nth(1)).not.toHaveAttribute('aria-hidden', 'true');
+	await expect(columns.nth(1)).not.toHaveAttribute('role', 'tabpanel');
+
+	// Now at phone width, where the switcher actually appears and the same mechanism legitimately
+	// hides the non-selected column from assistive tech.
+	await page.setViewportSize({ width: 390, height: 780 });
+	await page.reload();
+
+	const tabs = page.getByRole('tablist', { name: 'Spaltenauswahl' }).getByRole('tab');
+	await expect(tabs).toHaveCount(2);
+	await expect(tabs.first()).toHaveAttribute('aria-selected', 'true');
+	await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'false');
+	await expect(tabs.first()).toHaveAttribute('tabindex', '0');
+	await expect(tabs.nth(1)).toHaveAttribute('tabindex', '-1');
+
+	const mobileColumns = page.locator('.flow-column');
+	await expect(mobileColumns.first()).toHaveAttribute('role', 'tabpanel');
+	await expect(mobileColumns.nth(1)).toHaveAttribute('aria-hidden', 'true');
+
+	// ArrowRight moves focus to the next tab and switches to it in the same step (automatic
+	// activation), matching the existing click-to-switch behaviour. Read the focused id back from
+	// the same round trip that dispatches the key, rather than polling for it afterwards: this
+	// sandbox's headless browser can drop DOM focus asynchronously some time after a programmatic
+	// `.focus()` call for reasons unrelated to the app (the handler itself sets it synchronously,
+	// every time), and a later, separate assertion would be at the mercy of that.
+	await tabs.first().focus();
+	const focusedIdAfterArrowRight = await page.evaluate(() => {
+		document.activeElement?.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true })
+		);
+		return document.activeElement?.id;
+	});
+	expect(focusedIdAfterArrowRight).toBe('mobile-tab-1');
+	await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+	await expect(mobileColumns.first()).toHaveAttribute('aria-hidden', 'true');
+	await expect(mobileColumns.nth(1)).not.toHaveAttribute('aria-hidden', 'true');
+});
+
 test('legacy URLs from the previous site still resolve', async ({ page }) => {
 	await page.goto('/async/Joh3');
 	await expect(page).toHaveURL(/\/Joh3$/);

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -152,6 +152,71 @@ test('verses stay aligned across columns', async ({ page }) => {
 	expect(new Set(verse16.map((cell) => cell.column)).size).toBe(verse16.length);
 });
 
+test('a column boundary can be dragged to resize the columns, and the split persists', async ({
+	page
+}) => {
+	await useAlignedLayout(page);
+	await page.goto('/Joh3');
+
+	// The desktop bar; the mobile tab-switcher bar shares the same test id but is hidden at this
+	// (default) viewport width and never renders a resize handle at all.
+	const bar = page.getByTestId('column-picker-bar').first();
+	const handle = bar.getByRole('separator');
+	await expect(handle).toHaveCount(1);
+
+	const barBox = (await bar.boundingBox())!;
+	const handleBox = (await handle.boundingBox())!;
+	const startX = handleBox.x + handleBox.width / 2;
+	const y = handleBox.y + handleBox.height / 2;
+	const targetX = startX + barBox.width * 0.2;
+
+	// Dispatches synthetic pointer events directly rather than driving `page.mouse`: the handler
+	// computes the new width from this event's own `clientX` against the position recorded at
+	// pointerdown, not incrementally, so one pointermove carrying the final coordinate is enough —
+	// and this sidesteps a CDP/headless-Chromium quirk where a real synthetic mouse-up can go
+	// undelivered if the element under the cursor was itself moved (by our own live-resize feedback)
+	// since the preceding mouse-move.
+	await handle.dispatchEvent('pointerdown', { clientX: startX, clientY: y, pointerId: 1 });
+	await page.evaluate(
+		([x, pointerY]) => {
+			window.dispatchEvent(
+				new PointerEvent('pointermove', { clientX: x, clientY: pointerY, bubbles: true })
+			);
+		},
+		[targetX, y]
+	);
+	await page.evaluate(() => {
+		window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+	});
+
+	// The boundary moved right, so the first column grew and the second shrank.
+	const columnHeaders = bar.locator('[role="group"]');
+	const [firstWidth, secondWidth] = await columnHeaders.evaluateAll((nodes) =>
+		nodes.map((node) => node.getBoundingClientRect().width)
+	);
+	expect(firstWidth).toBeGreaterThan(secondWidth * 1.3);
+
+	// The resize commits to a cookie once the drag ends.
+	await expect.poll(() => page.evaluate(() => document.cookie)).toContain('column-widths=');
+
+	// The split survives a reload.
+	await page.reload();
+	const [firstAfterReload, secondAfterReload] = await columnHeaders.evaluateAll((nodes) =>
+		nodes.map((node) => node.getBoundingClientRect().width)
+	);
+	expect(firstAfterReload).toBeGreaterThan(secondAfterReload * 1.3);
+
+	// And still applies after switching to the flow layout.
+	await page.getByRole('button', { name: 'Ansicht' }).click();
+	await page.getByRole('menuitem', { name: /Fließtext/ }).click();
+	const flowColumns = page.locator('.flow-column');
+	await expect(flowColumns).toHaveCount(2);
+	const [flowFirst, flowSecond] = await flowColumns.evaluateAll((nodes) =>
+		nodes.map((node) => node.getBoundingClientRect().width)
+	);
+	expect(flowFirst).toBeGreaterThan(flowSecond * 1.3);
+});
+
 test('the view menu switches to synchronized flowing text', async ({ page }) => {
 	await page.goto('/Joh3');
 	expect(await page.evaluate(() => window.scrollY)).toBe(0);

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -218,6 +218,30 @@ test('a verse reference scrolls directly to the requested verse', async ({ page 
 	expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
 });
 
+test('landing on a deep-linked verse settles once, without a spurious extra prepend', async ({
+	page
+}) => {
+	await useAlignedLayout(page);
+	await page.setViewportSize({ width: 900, height: 260 });
+	await page.goto('/Joh3,16');
+
+	await expect(page.locator('.verse.highlighted').first()).toBeInViewport();
+
+	// The scroll that lands on the deep-linked verse is our own programmatic scroll, not the reader
+	// scrolling, so it must not be misread as "the reader scrolled near the top of the stream" and
+	// spuriously prepend the previous chapter — nobody asked to see it yet. Before the fix, the
+	// unsuppressed `scrollIntoView` left exactly that scroll event unshielded.
+	await page.waitForTimeout(600);
+	await expect(page.locator('.aligned-chapter[data-chapter-key="43:2"]')).toHaveCount(0);
+
+	// And once the landing scroll has settled, nothing keeps nudging it further — two polls apart
+	// see the same position, rather than the page still fighting its own compensating scrolls.
+	const first = await page.evaluate(() => window.scrollY);
+	await page.waitForTimeout(150);
+	const second = await page.evaluate(() => window.scrollY);
+	expect(second).toBe(first);
+});
+
 test('changing the reference resets aligned scrolling and the visible chapter', async ({
 	page
 }) => {

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -201,6 +201,54 @@ test('the view menu switches to synchronized flowing text', async ({ page }) => 
 	await expect(reader).toBeVisible();
 });
 
+test('a column can opt out of synchronized flowing-text scrolling on its own', async ({ page }) => {
+	// The fixture's chapter is short enough that almost any scroll position also crosses the endless-
+	// scroll thresholds, whose chapter-prepend compensation moves *every* column regardless of sync
+	// (by design — see onFlowScroll). Blocking it isolates the cross-column sync behaviour this test
+	// is actually about.
+	await page.route('**/api/reader/**', (route) => route.abort());
+	await page.goto('/Joh3');
+
+	const columns = page.locator('.flow-column');
+	await expect(columns).toHaveCount(2);
+
+	// Both columns start synced, so both toggles offer to disable it.
+	const disableToggle = page.getByRole('button', { name: 'Synchron scrollen deaktivieren' });
+	await expect(disableToggle).toHaveCount(2);
+	await disableToggle.nth(1).click();
+	await expect(page.getByRole('button', { name: 'Synchron scrollen aktivieren' })).toHaveCount(1);
+
+	// Let any in-flight sync from the initial mount settle, then take the second column's resting
+	// position as the baseline to compare against — rather than assuming it is 0, which the
+	// mount-time alignment (while still synced) need not leave it at.
+	await page.waitForTimeout(400);
+	const baseline = await columns.nth(1).evaluate((element) => element.scrollTop);
+
+	// Scrolling the still-synced first column must not move the column that opted out.
+	await columns.first().evaluate((element) => {
+		const verse = element.querySelector<HTMLElement>('[data-verse-key="43:3:17"]');
+		element.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+		element.scrollTop = verse?.offsetTop ?? element.scrollHeight;
+		element.dispatchEvent(new Event('scroll'));
+	});
+	await page.waitForTimeout(400);
+	expect(await columns.nth(1).evaluate((element) => element.scrollTop)).toBe(baseline);
+
+	// Re-enabling resumes sync from the next real scroll: scrolling the first column back to the top
+	// re-anchors the second column on verse 16 instead of wherever it was left.
+	await page.getByRole('button', { name: 'Synchron scrollen aktivieren' }).click();
+	await expect(page.getByRole('button', { name: 'Synchron scrollen deaktivieren' })).toHaveCount(2);
+
+	await columns.first().evaluate((element) => {
+		element.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+		element.scrollTop = 0;
+		element.dispatchEvent(new Event('scroll'));
+	});
+	await expect
+		.poll(() => columns.nth(1).evaluate((element) => element.scrollTop))
+		.not.toBe(baseline);
+});
+
 test('flowing text preloads the next chapter for endless scrolling', async ({ page }) => {
 	await page.goto('/Joh3');
 	await page.getByRole('button', { name: 'Ansicht' }).click();

--- a/src/lib/components/ColumnPicker.svelte
+++ b/src/lib/components/ColumnPicker.svelte
@@ -21,7 +21,9 @@
 		available,
 		chosen,
 		canRemove,
-		canAdd = false
+		canAdd = false,
+		flowSyncEnabled = true,
+		showFlowSyncToggle = false
 	}: {
 		index: number;
 		selected: ReadableResource;
@@ -31,6 +33,11 @@
 		canRemove: boolean;
 		/** Shows the "add a column" button; set on the last column only, so the grid keeps its shape. */
 		canAdd?: boolean;
+		/** Whether this column currently takes part in the flow layout's cross-column scroll sync. */
+		flowSyncEnabled?: boolean;
+		/** Shows the sync toggle at all; only meaningful in the flow layout, where columns scroll
+		 *  independently — the aligned layout has no per-column scrolling to opt out of. */
+		showFlowSyncToggle?: boolean;
 	} = $props();
 
 	let selectMenu: Menu | undefined = $state();
@@ -52,6 +59,49 @@
 			<circle cx="3" cy="15" r="1.2" /><circle cx="9" cy="15" r="1.2" />
 		</svg>
 	</span>
+
+	{#if showFlowSyncToggle}
+		<form
+			method="POST"
+			action="?/setColumnFlowSync"
+			use:enhance
+			class="flex items-center self-stretch"
+		>
+			<input type="hidden" name="resource" value={selected.id} />
+			<button
+				type="submit"
+				title={flowSyncEnabled ? t('reader.flowSyncDisable') : t('reader.flowSyncEnable')}
+				aria-label={flowSyncEnabled ? t('reader.flowSyncDisable') : t('reader.flowSyncEnable')}
+				aria-pressed={flowSyncEnabled}
+				class="inline-flex size-7 items-center justify-center rounded text-stone-400
+				       hover:bg-stone-100 hover:text-stone-700 dark:hover:bg-stone-800 dark:hover:text-stone-200"
+				class:text-accent-600={flowSyncEnabled}
+				class:dark:text-accent-400={flowSyncEnabled}
+			>
+				<svg viewBox="0 0 20 20" class="size-4" fill="currentColor" aria-hidden="true">
+					<path
+						fill-rule="evenodd"
+						d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z"
+						clip-rule="evenodd"
+					/>
+					<path
+						fill-rule="evenodd"
+						d="M7.768 15.768a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3Z"
+						clip-rule="evenodd"
+					/>
+					{#if !flowSyncEnabled}
+						<path
+							d="M3.5 3.5l13 13"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							fill="none"
+						/>
+					{/if}
+				</svg>
+			</button>
+		</form>
+	{/if}
 
 	<button
 		id="column-{index}"

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -63,6 +63,7 @@ export const de = {
 	'reader.flowSyncEnable': 'Synchron scrollen aktivieren',
 	'reader.flowSyncDisable': 'Synchron scrollen deaktivieren',
 	'reader.resizeColumns': 'Spaltenbreite anpassen',
+	'reader.mobileColumnsTablist': 'Spaltenauswahl',
 	'resource.group.bibles': 'Bibeln',
 	'resource.group.commentaries': 'Kommentare',
 	'resource.group.xrefs': 'Parallelstellen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -60,6 +60,8 @@ export const de = {
 	'reader.viewFlowHint': 'Jede Übersetzung läuft ohne Lücken als fortlaufender Text.',
 	'reader.textSize': 'Textgröße',
 	'reader.colorScheme': 'Farbschema',
+	'reader.flowSyncEnable': 'Synchron scrollen aktivieren',
+	'reader.flowSyncDisable': 'Synchron scrollen deaktivieren',
 	'resource.group.bibles': 'Bibeln',
 	'resource.group.commentaries': 'Kommentare',
 	'resource.group.xrefs': 'Parallelstellen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -62,6 +62,7 @@ export const de = {
 	'reader.colorScheme': 'Farbschema',
 	'reader.flowSyncEnable': 'Synchron scrollen aktivieren',
 	'reader.flowSyncDisable': 'Synchron scrollen deaktivieren',
+	'reader.resizeColumns': 'Spaltenbreite anpassen',
 	'resource.group.bibles': 'Bibeln',
 	'resource.group.commentaries': 'Kommentare',
 	'resource.group.xrefs': 'Parallelstellen',

--- a/src/lib/server/columns.ts
+++ b/src/lib/server/columns.ts
@@ -134,3 +134,70 @@ export function moveColumn(columns: string[], from: number, to: number): string[
 }
 
 export { MAX_COLUMNS };
+
+/**
+ * Per-column widths for the reader grid, as fractions of the row that sum to 1.
+ *
+ * Kept in a cookie of `id:fraction` pairs, like `COLUMNS_COOKIE` keyed by resource id rather than
+ * position, so a drag-resize survives a reorder — the width follows the translation, not the slot.
+ */
+export const COLUMN_WIDTHS_COOKIE = 'column-widths';
+
+/** A column may not shrink below this share of the row, so a boundary drag can never squeeze a
+ *  neighbour into unreadable ribbon. */
+export const MIN_COLUMN_FRACTION = 0.12;
+
+/**
+ * Clamps every width to the minimum share and renormalizes so the row still sums to 1 — clamping
+ * alone could leave the total under or over the space the row actually has. Falls back to an equal
+ * split whenever the count does not match `count` (or a width is not a usable number), since a stale
+ * set of fractions cannot mean anything for a different number of columns.
+ */
+export function normalizeColumnWidths(widths: number[], count: number): number[] {
+	if (count <= 0) return [];
+	if (widths.length !== count || widths.some((width) => !Number.isFinite(width) || width <= 0)) {
+		return Array(count).fill(1 / count);
+	}
+
+	const clamped = widths.map((width) => Math.max(MIN_COLUMN_FRACTION, width));
+	const total = clamped.reduce((sum, width) => sum + width, 0);
+	return clamped.map((width) => width / total);
+}
+
+/**
+ * This device's stored widths, in the same order as `columnIds`, or `null` when the reader has not
+ * customized them (no cookie yet) or the stored id set no longer matches the current columns — an
+ * add or a remove since the widths were last saved leaves them meaning nothing, so the caller falls
+ * back to an even split rather than rendering a stale layout.
+ */
+export function resolveColumnWidths(cookies: Cookies, columnIds: string[]): number[] | null {
+	if (columnIds.length === 0) return null;
+
+	const stored = cookies.get(COLUMN_WIDTHS_COOKIE);
+	if (!stored) return null;
+
+	const byId = new Map<string, number>();
+	for (const pair of stored.split(',')) {
+		const [id, fraction] = pair.split(':');
+		if (id && fraction !== undefined) byId.set(id, Number(fraction));
+	}
+
+	if (byId.size !== columnIds.length || !columnIds.every((id) => byId.has(id))) return null;
+	return normalizeColumnWidths(
+		columnIds.map((id) => byId.get(id) ?? 0),
+		columnIds.length
+	);
+}
+
+export function writeColumnWidths(cookies: Cookies, columnIds: string[], widths: number[]): void {
+	const normalized = normalizeColumnWidths(widths, columnIds.length);
+	const value = columnIds
+		.map((id, index) => `${id}:${(normalized[index] ?? 0).toFixed(4)}`)
+		.join(',');
+	cookies.set(COLUMN_WIDTHS_COOKIE, value, {
+		path: '/',
+		maxAge: COOKIE_MAX_AGE_SECONDS,
+		httpOnly: false,
+		sameSite: 'lax'
+	});
+}

--- a/src/lib/server/reader-preferences.ts
+++ b/src/lib/server/reader-preferences.ts
@@ -16,6 +16,7 @@ export const MIN_FONT_SCALE = 85;
 export const MAX_FONT_SCALE = 140;
 export const FONT_SCALE_STEP = 5;
 export const READER_LAYOUT_COOKIE = 'reader-layout';
+export const FLOW_SYNC_DISABLED_COOKIE = 'flow-sync-disabled';
 export const THEME_COOKIE = 'theme';
 export type ReaderLayout = 'aligned' | 'flow';
 export type Theme = 'light' | 'dark';
@@ -60,6 +61,31 @@ export function readReaderLayout(
 
 export function writeReaderLayout(cookies: Cookies, layout: ReaderLayout): void {
 	cookies.set(READER_LAYOUT_COOKIE, layout, {
+		path: '/',
+		maxAge: COOKIE_MAX_AGE_SECONDS,
+		httpOnly: false,
+		sameSite: 'lax'
+	});
+}
+
+/**
+ * Which columns have opted out of the flow layout's cross-column scroll sync, keyed by resource id
+ * rather than column position — a column keeps its own sync preference across a reorder or a swap to a
+ * different translation slot, since the id, not the position, is what a reader means by "this column".
+ */
+export function readFlowSyncDisabled(cookies: Cookies): Set<string> {
+	const stored = cookies.get(FLOW_SYNC_DISABLED_COOKIE);
+	if (!stored) return new Set();
+	return new Set(
+		stored
+			.split(',')
+			.map((id) => id.trim())
+			.filter((id) => id.length > 0)
+	);
+}
+
+export function writeFlowSyncDisabled(cookies: Cookies, disabled: ReadonlySet<string>): void {
+	cookies.set(FLOW_SYNC_DISABLED_COOKIE, [...disabled].join(','), {
 		path: '/',
 		maxAge: COOKIE_MAX_AGE_SECONDS,
 		httpOnly: false,

--- a/src/routes/[...reference]/+page.server.ts
+++ b/src/routes/[...reference]/+page.server.ts
@@ -35,8 +35,10 @@ import {
 import {
 	MAX_FONT_SCALE,
 	MIN_FONT_SCALE,
+	readFlowSyncDisabled,
 	readFontScale,
 	readReaderLayout,
+	writeFlowSyncDisabled,
 	writeReaderLayout,
 	writeFontScale
 } from '$lib/server/reader-preferences';
@@ -157,6 +159,9 @@ export async function load({ params, cookies, url, setHeaders, locals }) {
 	const marked = locals.user
 		? await markedVersesByList(db, locals.user.id, reference.book, reference.chapter)
 		: [];
+	// Which columns have opted out of the flow layout's cross-column scroll sync, kept by resource id
+	// so the choice survives a reorder or a translation swap in the same slot.
+	const flowSyncDisabled = readFlowSyncDisabled(cookies);
 	const notesVisible = cookies.get('chapter-notes-visible') === '1';
 	const chapterNote =
 		locals.user && notesVisible
@@ -195,6 +200,10 @@ export async function load({ params, cookies, url, setHeaders, locals }) {
 				covers: coverage.get(id)?.has(reference.book) ?? false
 			};
 		}),
+		/** Whether each column (in the same order as `columns` above) takes part in the flow layout's
+		 *  cross-column scroll sync; a column not currently selected has nothing to intersect against
+		 *  and simply does not appear here. */
+		flowSyncEnabled: columns.map((id) => !flowSyncDisabled.has(id)),
 		navigation: {
 			previous: previousChapter(reference.book, reference.chapter),
 			next: nextChapter(reference.book, reference.chapter),
@@ -287,6 +296,20 @@ export const actions = {
 			httpOnly: false,
 			sameSite: 'lax'
 		});
+		return { success: true };
+	},
+
+	/** Flips one column's participation in the flow layout's cross-column scroll sync. Keyed by
+	 *  resource id rather than column index, like the cookie itself, so the choice survives a reorder. */
+	setColumnFlowSync: async ({ request, cookies }) => {
+		const form = await request.formData();
+		const resource = String(form.get('resource') ?? '');
+		if (!resource) return fail(400, { error: 'resource' });
+
+		const disabled = readFlowSyncDisabled(cookies);
+		if (disabled.has(resource)) disabled.delete(resource);
+		else disabled.add(resource);
+		writeFlowSyncDisabled(cookies, disabled);
 		return { success: true };
 	},
 

--- a/src/routes/[...reference]/+page.server.ts
+++ b/src/routes/[...reference]/+page.server.ts
@@ -14,9 +14,11 @@ import {
 	addColumn,
 	moveColumn,
 	resolveColumns,
+	resolveColumnWidths,
 	removeColumn,
 	setColumn,
-	writeColumns
+	writeColumns,
+	writeColumnWidths
 } from '$lib/server/columns';
 import { loadChapter } from '$lib/server/repositories/chapter';
 import { loadReferenceResources } from '$lib/server/repositories/reference-resources';
@@ -204,6 +206,9 @@ export async function load({ params, cookies, url, setHeaders, locals }) {
 		 *  cross-column scroll sync; a column not currently selected has nothing to intersect against
 		 *  and simply does not appear here. */
 		flowSyncEnabled: columns.map((id) => !flowSyncDisabled.has(id)),
+		/** Custom per-column widths, in the same order as `columns` above, or `null` when the reader has
+		 *  not resized anything — the client then falls back to an even split via CSS. */
+		columnWidths: resolveColumnWidths(cookies, columns),
 		navigation: {
 			previous: previousChapter(reference.book, reference.chapter),
 			next: nextChapter(reference.book, reference.chapter),
@@ -284,6 +289,24 @@ export const actions = {
 			locals.user,
 			moveColumn(resolveColumns(cookies, bibles, locals.user?.readerColumns), from, to)
 		);
+		return { success: true };
+	},
+
+	/** Commits a drag-resize of the column boundaries. Widths are normalized and clamped again here —
+	 *  the client already does both live, but a request is never trusted at face value. */
+	setColumnWidths: async ({ request, cookies, locals }) => {
+		const form = await request.formData();
+		const widths = String(form.get('widths') ?? '')
+			.split(',')
+			.map(Number);
+
+		const bibles = await listReaderResources(getDb());
+		const columns = resolveColumns(cookies, bibles, locals.user?.readerColumns);
+		if (widths.length !== columns.length || widths.some((width) => !Number.isFinite(width))) {
+			return fail(400, { error: 'widths' });
+		}
+
+		writeColumnWidths(cookies, columns, widths);
 		return { success: true };
 	},
 

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -297,6 +297,55 @@
 	/** Which column a reader is looking at on a phone, where only one fits. */
 	let mobileColumn = $state(0);
 
+	/**
+	 * Whether the phone-width layout (one column visible, switched by tabs) is actually in effect —
+	 * not merely "the reader happens to be on a phone", since a desktop window can be narrowed too.
+	 *
+	 * `mobileColumn` only means something once this is true: on desktop every column is visible at
+	 * once, so gating `role="tabpanel"`/`aria-hidden` purely on `columnIndex !== mobileColumn` would
+	 * incorrectly hide every non-selected column from assistive tech there too, even though a sighted
+	 * desktop reader sees them all just fine.
+	 */
+	let isMobileViewport = $state(false);
+
+	$effect(() => {
+		const query = window.matchMedia('(max-width: 639px)');
+		isMobileViewport = query.matches;
+		const onChange = (event: MediaQueryListEvent) => {
+			isMobileViewport = event.matches;
+		};
+		query.addEventListener('change', onChange);
+		return () => query.removeEventListener('change', onChange);
+	});
+
+	let mobileTablist = $state<HTMLElement | undefined>();
+
+	/**
+	 * Roving focus for the mobile column tabs, matching `Menu.svelte`'s own arrow-key handling.
+	 * "Automatic activation": moving focus also switches `mobileColumn`, the same as a click — there
+	 * is no separate "activate" step, matching the existing click-to-switch behaviour exactly.
+	 */
+	function onMobileTabKeydown(event: KeyboardEvent) {
+		if (!mobileTablist) return;
+		const tabs = [...mobileTablist.querySelectorAll<HTMLElement>('[role="tab"]')];
+		if (tabs.length === 0) return;
+
+		const current = tabs.indexOf(document.activeElement as HTMLElement);
+		let next: number | null = null;
+
+		if (event.key === 'ArrowRight') next = (current + 1) % tabs.length;
+		else if (event.key === 'ArrowLeft') next = (current - 1 + tabs.length) % tabs.length;
+		else if (event.key === 'Home') next = 0;
+		else if (event.key === 'End') next = tabs.length - 1;
+
+		if (next === null) return;
+		event.preventDefault();
+		const target = tabs[next];
+		target?.focus();
+		const index = Number(target?.id.replace('mobile-tab-', ''));
+		if (Number.isFinite(index)) mobileColumn = index;
+	}
+
 	/** Strong's number shown in the study sidebar, kept in the URL hash so it can be shared. */
 	let activeStrong = $state<{ strong: string; word: string; reference: string } | null>(null);
 
@@ -1059,32 +1108,53 @@
 				       dark:border-stone-800 dark:bg-stone-950/95"
 				data-testid="column-picker-bar"
 			>
-				{#each data.columns as column (column.resource.id)}
-					<button
-						type="button"
-						class="shrink-0 rounded-full px-3 py-1 text-sm"
-						class:bg-accent-600={mobileColumn === column.index}
-						class:text-white={mobileColumn === column.index}
-						class:bg-stone-100={mobileColumn !== column.index}
-						class:dark:bg-stone-800={mobileColumn !== column.index}
-						onclick={() => (mobileColumn = column.index)}
-					>
-						{column.resource.abbrev}
-					</button>
-				{/each}
-				{#if data.notesVisible}
-					<button
-						type="button"
-						class="shrink-0 rounded-full px-3 py-1 text-sm"
-						class:bg-accent-600={mobileColumn === notesColumnIndex}
-						class:text-white={mobileColumn === notesColumnIndex}
-						class:bg-stone-100={mobileColumn !== notesColumnIndex}
-						class:dark:bg-stone-800={mobileColumn !== notesColumnIndex}
-						onclick={() => (mobileColumn = notesColumnIndex)}
-					>
-						{t('lists.note')}
-					</button>
-				{/if}
+				<!-- The tablist container itself is never a stop on the Tab key — only the tabs are, via
+				     their own roving tabindex below — so it does not need one of its own either. -->
+				<!-- svelte-ignore a11y_interactive_supports_focus -->
+				<div
+					bind:this={mobileTablist}
+					role="tablist"
+					aria-label={t('reader.mobileColumnsTablist')}
+					class="contents"
+					onkeydown={onMobileTabKeydown}
+				>
+					{#each data.columns as column (column.resource.id)}
+						<button
+							type="button"
+							role="tab"
+							id="mobile-tab-{column.index}"
+							aria-selected={mobileColumn === column.index}
+							aria-controls="mobile-tabpanel-{column.index}"
+							tabindex={mobileColumn === column.index ? 0 : -1}
+							class="mobile-tab shrink-0 rounded-full px-3 py-1 text-sm"
+							class:bg-accent-600={mobileColumn === column.index}
+							class:text-white={mobileColumn === column.index}
+							class:bg-stone-100={mobileColumn !== column.index}
+							class:dark:bg-stone-800={mobileColumn !== column.index}
+							onclick={() => (mobileColumn = column.index)}
+						>
+							{column.resource.abbrev}
+						</button>
+					{/each}
+					{#if data.notesVisible}
+						<button
+							type="button"
+							role="tab"
+							id="mobile-tab-{notesColumnIndex}"
+							aria-selected={mobileColumn === notesColumnIndex}
+							aria-controls="mobile-tabpanel-{notesColumnIndex}"
+							tabindex={mobileColumn === notesColumnIndex ? 0 : -1}
+							class="mobile-tab shrink-0 rounded-full px-3 py-1 text-sm"
+							class:bg-accent-600={mobileColumn === notesColumnIndex}
+							class:text-white={mobileColumn === notesColumnIndex}
+							class:bg-stone-100={mobileColumn !== notesColumnIndex}
+							class:dark:bg-stone-800={mobileColumn !== notesColumnIndex}
+							onclick={() => (mobileColumn = notesColumnIndex)}
+						>
+							{t('lists.note')}
+						</button>
+					{/if}
+				</div>
 
 				{#if canAddColumn}
 					<form method="POST" action="?/addColumn" use:enhance>
@@ -1131,8 +1201,11 @@
 							data-flow-column-index={columnIndex}
 							class="flow-column"
 							class:hidden-on-mobile={columnIndex !== mobileColumn}
-							role="region"
-							aria-label={column.resource.name}
+							role={isMobileViewport ? 'tabpanel' : 'region'}
+							id={isMobileViewport ? `mobile-tabpanel-${columnIndex}` : undefined}
+							aria-labelledby={isMobileViewport ? `mobile-tab-${columnIndex}` : undefined}
+							aria-label={isMobileViewport ? undefined : column.resource.name}
+							aria-hidden={isMobileViewport && columnIndex !== mobileColumn}
 							onwheel={() => makeFlowSource(columnIndex)}
 							ontouchstart={() => makeFlowSource(columnIndex)}
 							onpointerdown={() => makeFlowSource(columnIndex)}
@@ -1319,6 +1392,10 @@
 						<aside
 							class="flow-column flow-note"
 							class:hidden-on-mobile={mobileColumn !== notesColumnIndex}
+							role={isMobileViewport ? 'tabpanel' : undefined}
+							id={isMobileViewport ? `mobile-tabpanel-${notesColumnIndex}` : undefined}
+							aria-labelledby={isMobileViewport ? `mobile-tab-${notesColumnIndex}` : undefined}
+							aria-hidden={isMobileViewport && mobileColumn !== notesColumnIndex}
 						>
 							{#each streamChapters as stream (`note:${stream.reference.book}:${stream.reference.chapter}`)}
 								<div
@@ -1637,6 +1714,34 @@
 	.column-resize-handle:focus-visible {
 		outline: 2px solid var(--color-accent-500);
 		outline-offset: -2px;
+	}
+
+	/* The mobile column tabs. The pill's background already shows which one is selected; the
+	   underline is a second, less color-dependent cue, and the one that actually animates. */
+	.mobile-tab {
+		position: relative;
+	}
+
+	.mobile-tab::after {
+		position: absolute;
+		right: 20%;
+		bottom: -0.35rem;
+		left: 20%;
+		height: 2px;
+		border-radius: 1px;
+		background: var(--color-accent-500);
+		opacity: 0;
+		transition: opacity 150ms ease;
+		content: '';
+	}
+
+	.mobile-tab[aria-selected='true']::after {
+		opacity: 1;
+	}
+
+	.mobile-tab:focus-visible {
+		outline: 2px solid var(--color-accent-500);
+		outline-offset: 2px;
 	}
 
 	.license-grid {

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -55,6 +55,11 @@
 		data.columns.length < data.maxColumns && unusedResources.length > 0
 	);
 	const visibleColumnCount = $derived(data.columns.length + (data.notesVisible ? 1 : 0));
+	/** Which columns take part in the flow layout's cross-column scroll sync, in the same order as
+	 *  `data.columns`. Server-derived (from a cookie keyed by resource id), like `data.notesVisible` —
+	 *  the toggle round-trips through `?/setColumnFlowSync` rather than flipping local state, so it
+	 *  stays correct after a reorder or translation swap without any client-side bookkeeping of its own. */
+	const flowSyncEnabled = $derived(data.flowSyncEnabled);
 	const notesColumnIndex = $derived(data.columns.length);
 
 	function commentaryAt(
@@ -620,6 +625,7 @@
 	 * scrolled past the anchor line by the time this first runs), even though nothing was scrolled.
 	 */
 	function syncFlowColumns(sourceIndex = 0, trackAddress = false) {
+		if (!flowSyncEnabled[sourceIndex]) return;
 		const source = flowColumns[sourceIndex];
 		if (!source || data.readerLayout !== 'flow') return;
 		const anchorInset = 12;
@@ -633,6 +639,7 @@
 
 		for (let index = 0; index < flowColumns.length; index += 1) {
 			if (index === sourceIndex) continue;
+			if (!flowSyncEnabled[index]) continue;
 			const column = flowColumns[index];
 			const target = column && findVerseElement(column, anchor.dataset.verseKey, anchorVerse);
 			if (!column || !target) continue;
@@ -653,6 +660,7 @@
 	}
 
 	function makeFlowSource(columnIndex: number) {
+		if (!flowSyncEnabled[columnIndex]) return;
 		activeFlowSource = columnIndex;
 		if (suppressFlowTimer) clearTimeout(suppressFlowTimer);
 		suppressFlowScroll = false;
@@ -681,11 +689,15 @@
 	 */
 	function onFlowScroll(columnIndex: number) {
 		if (suppressFlowScroll) return;
-		activeFlowSource = columnIndex;
 		const source = flowColumns[columnIndex];
 		if (!source) return;
+		// Sync off does not stop this column's own endless-scroll loading below — only the two lines
+		// that would make it the sync source are skipped.
+		if (flowSyncEnabled[columnIndex]) {
+			activeFlowSource = columnIndex;
+			scheduleFlowSync(columnIndex);
+		}
 		updateVisibleChapter(source, 12);
-		scheduleFlowSync(columnIndex);
 		if (source.scrollTop < 500) void loadStreamPrevious();
 		if (source.scrollHeight - source.scrollTop - source.clientHeight < 900) void loadStreamNext();
 	}
@@ -821,6 +833,8 @@
 							chosen={data.columns.map((other) => other.resource.id)}
 							canRemove={data.columns.length > 1}
 							canAdd={canAddColumn && column.index === data.columns.length - 1}
+							flowSyncEnabled={flowSyncEnabled[column.index] ?? true}
+							showFlowSyncToggle={data.readerLayout === 'flow'}
 						/>
 					</div>
 				{/each}

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -113,6 +113,148 @@
 	}
 
 	/**
+	 * Drag-resizable column widths, as fractions of the row that sum to 1.
+	 *
+	 * `null` means "not customized yet" — the grid then falls back to an even split via the
+	 * `--column-track` CSS variable's own fallback, rather than this rendering an explicit (if
+	 * numerically equivalent) track of its own for no reason.
+	 */
+	let columnWidths = $state<number[] | null>(data.columnWidths);
+	/** Detects a reorder, add, remove or swap — not a mere navigation, which leaves the id list (and
+	 *  therefore this key) unchanged — so a resize commit's own round trip does not clobber the widths
+	 *  the reader just set. Kept separate from `streamColumnsKey` above: that one resets the *chapter*
+	 *  stream, this one only cares whether the *columns* changed. */
+	let columnWidthsKey = data.columns.map((column) => column.resource.id).join(',');
+	const MIN_COLUMN_FRACTION = 0.12;
+
+	$effect(() => {
+		const key = data.columns.map((column) => column.resource.id).join(',');
+		if (key !== columnWidthsKey) {
+			columnWidthsKey = key;
+			// The server already recomputed this in the new order (a reorder) or decided the old
+			// widths no longer apply (an add/remove/swap, where it comes back `null`) — either way,
+			// adopting its answer is correct, not just a reset.
+			columnWidths = data.columnWidths;
+		}
+	});
+
+	function equalColumnWidths(): number[] {
+		return data.columns.map(() => 1 / data.columns.length);
+	}
+
+	/** The row's grid track, or `undefined` while `columnWidths` is `null` so the CSS fallback (an
+	 *  even `repeat()` split) applies untouched. `minmax(0, …)` matches the original bare `1fr` tracks
+	 *  so a narrow custom width can still shrink below its content's own minimum, exactly like before. */
+	const columnTrack = $derived(
+		columnWidths
+			? columnWidths.map((width) => `minmax(0, ${width}fr)`).join(' ') +
+					(data.notesVisible ? ' minmax(0, 1fr)' : '')
+			: undefined
+	);
+	/** The desktop header bar sets `grid-template-columns` inline rather than through a class, so it
+	 *  cannot lean on the CSS variable's own fallback and needs the equivalent literal spelled out. */
+	const headerGridTemplate = $derived(
+		columnTrack ?? `repeat(${visibleColumnCount}, minmax(0, 1fr))`
+	);
+
+	/** Left-edge percentage, across the *whole* header row (including a visible notes column), of each
+	 *  boundary between two real columns — where the resize handles sit. */
+	const columnBoundaryPercents = $derived.by(() => {
+		const fractions = columnWidths ?? equalColumnWidths();
+		// Both branches of `fractions` already sum to 1 across the real columns as a group (an equal
+		// split of N columns is N × 1/N); the notes column, when visible, then adds one more same-sized
+		// unit, matching how `columnTrack` appends it as a further `1fr` after that group.
+		const totalUnits = 1 + (data.notesVisible ? 1 : 0);
+		const percents: number[] = [];
+		let cumulative = 0;
+		for (let index = 0; index < fractions.length - 1; index += 1) {
+			cumulative += fractions[index] ?? 0;
+			percents.push((cumulative / totalUnits) * 100);
+		}
+		return percents;
+	});
+
+	let columnHeaderBar = $state<HTMLElement>();
+	let isResizingColumns = false;
+	let resizeBoundaryIndex: number | null = null;
+	let resizeStartX = 0;
+	let resizeStartWidths: number[] = [];
+	let resizeBarWidth = 0;
+	let widthsForm = $state<HTMLFormElement | undefined>();
+	let widthsInput = $state<HTMLInputElement | undefined>();
+
+	function clampBoundary(widths: number[], boundaryIndex: number, nextLeft: number): number[] {
+		const next = [...widths];
+		const left = next[boundaryIndex] ?? 0;
+		const right = next[boundaryIndex + 1] ?? 0;
+		const pairTotal = left + right;
+		const clampedLeft = Math.max(
+			MIN_COLUMN_FRACTION,
+			Math.min(pairTotal - MIN_COLUMN_FRACTION, nextLeft)
+		);
+		next[boundaryIndex] = clampedLeft;
+		next[boundaryIndex + 1] = pairTotal - clampedLeft;
+		return next;
+	}
+
+	function startColumnResize(event: PointerEvent, boundaryIndex: number) {
+		if (!columnHeaderBar) return;
+		isResizingColumns = true;
+		resizeBoundaryIndex = boundaryIndex;
+		resizeStartX = event.clientX;
+		resizeStartWidths = columnWidths ?? equalColumnWidths();
+		resizeBarWidth = columnHeaderBar.getBoundingClientRect().width;
+	}
+
+	/** Bound to `<svelte:window>`, not the handle itself: a pointer that leaves the handle mid-drag
+	 *  (fast movement, or the handle itself moving out from under the pointer) must keep resizing. */
+	function onColumnResizeMove(event: PointerEvent) {
+		if (!isResizingColumns || resizeBoundaryIndex === null || resizeBarWidth <= 0) return;
+		const deltaFraction = (event.clientX - resizeStartX) / resizeBarWidth;
+		columnWidths = clampBoundary(
+			resizeStartWidths,
+			resizeBoundaryIndex,
+			(resizeStartWidths[resizeBoundaryIndex] ?? 0) + deltaFraction
+		);
+	}
+
+	function onColumnResizeEnd() {
+		if (!isResizingColumns) return;
+		isResizingColumns = false;
+		resizeBoundaryIndex = null;
+		commitColumnWidths();
+	}
+
+	/** Keyboard equivalent of a pointer drag: `ArrowLeft`/`ArrowRight` nudge one boundary a couple of
+	 *  percentage points and commit immediately, since there is no separate "release" event. */
+	function onResizeHandleKeydown(event: KeyboardEvent, boundaryIndex: number) {
+		const step = 0.02;
+		if (event.key === 'ArrowLeft') {
+			event.preventDefault();
+			columnWidths = clampBoundary(
+				columnWidths ?? equalColumnWidths(),
+				boundaryIndex,
+				(columnWidths ?? equalColumnWidths())[boundaryIndex]! - step
+			);
+			commitColumnWidths();
+		} else if (event.key === 'ArrowRight') {
+			event.preventDefault();
+			columnWidths = clampBoundary(
+				columnWidths ?? equalColumnWidths(),
+				boundaryIndex,
+				(columnWidths ?? equalColumnWidths())[boundaryIndex]! + step
+			);
+			commitColumnWidths();
+		}
+	}
+
+	function commitColumnWidths() {
+		if (!columnWidths || !widthsForm || !widthsInput) return;
+		widthsInput.value = columnWidths.join(',');
+		widthsForm.requestSubmit();
+	}
+
+	/**
 	 * Opens the verse menu, unless the reader meant to use the link.
 	 *
 	 * The verse number stays an `<a>` so it keeps working without scripting and still offers
@@ -736,7 +878,11 @@
 	}
 </script>
 
-<svelte:window onscroll={onReaderWindowScroll} />
+<svelte:window
+	onscroll={onReaderWindowScroll}
+	onpointermove={onColumnResizeMove}
+	onpointerup={onColumnResizeEnd}
+/>
 
 <svelte:head>
 	<title>{data.fullTitle} — strongs.de</title>
@@ -799,11 +945,12 @@
 			<!-- Column headers double as the translation picker. The bar sticks as one piece; a single
 			     header cell is never taller than itself and so could never stick on its own. -->
 			<div
-				class="sticky top-[calc(var(--header-height)+2.75rem)] z-10 mb-2 hidden gap-0 overflow-hidden rounded-md border
-				       border-stone-200 bg-stone-50/95 py-1.5 shadow-sm backdrop-blur sm:grid
-				       dark:border-stone-800 dark:bg-stone-950/95"
+				bind:this={columnHeaderBar}
+				class="relative sticky top-[calc(var(--header-height)+2.75rem)] z-10 mb-2 hidden gap-0
+				       overflow-hidden rounded-md border border-stone-200 bg-stone-50/95 py-1.5 shadow-sm
+				       backdrop-blur sm:grid dark:border-stone-800 dark:bg-stone-950/95"
 				data-testid="column-picker-bar"
-				style="grid-template-columns: repeat({visibleColumnCount}, minmax(0, 1fr))"
+				style="grid-template-columns: {headerGridTemplate}"
 			>
 				{#each data.columns as column (column.resource.id)}
 					<div
@@ -860,10 +1007,49 @@
 						</form>
 					</div>
 				{/if}
+
+				<!-- An overlay rather than something inside each column cell, so a handle can straddle two
+				     of them at once. `pointer-events-none` on the wrapper keeps it from intercepting clicks
+				     on the picker buttons underneath, everywhere except the thin strip of each handle. -->
+				<div class="pointer-events-none absolute inset-0">
+					{#each columnBoundaryPercents as percent, boundaryIndex (boundaryIndex)}
+						<!-- A focusable, draggable separator is the documented WAI-ARIA "window splitter"
+						     pattern (role="separator" + tabindex + arrow-key support), not an oversight the
+						     linter's generic "non-interactive element" heuristic accounts for. -->
+						<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+						<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+						<div
+							role="separator"
+							aria-orientation="vertical"
+							aria-label={t('reader.resizeColumns')}
+							aria-valuenow={Math.round(
+								(columnWidths ?? equalColumnWidths())[boundaryIndex]! * 100
+							)}
+							aria-valuemin={Math.round(MIN_COLUMN_FRACTION * 100)}
+							aria-valuemax={Math.round(
+								(1 - MIN_COLUMN_FRACTION * (data.columns.length - 1)) * 100
+							)}
+							tabindex="0"
+							class="column-resize-handle"
+							style="left: {percent}%"
+							onpointerdown={(event) => startColumnResize(event, boundaryIndex)}
+							onkeydown={(event) => onResizeHandleKeydown(event, boundaryIndex)}
+						></div>
+					{/each}
+				</div>
 			</div>
 			<form bind:this={reorderForm} method="POST" action="?/moveColumn" use:enhance class="hidden">
 				<input bind:this={reorderFromInput} type="hidden" name="from" />
 				<input bind:this={reorderToInput} type="hidden" name="to" />
+			</form>
+			<form
+				bind:this={widthsForm}
+				method="POST"
+				action="?/setColumnWidths"
+				use:enhance
+				class="hidden"
+			>
+				<input bind:this={widthsInput} type="hidden" name="widths" />
 			</form>
 
 			<!-- On a phone one column fits; tabs switch between translations. -->
@@ -933,7 +1119,12 @@
 					{t('reader.chapterEmpty')}
 				</p>
 			{:else if data.readerLayout === 'flow'}
-				<div class="flow-reader" style="--columns: {visibleColumnCount}" data-testid="flow-reader">
+				<div
+					class="flow-reader"
+					style="--columns: {visibleColumnCount}"
+					style:--column-track={columnTrack}
+					data-testid="flow-reader"
+				>
 					{#each data.columns as column, columnIndex (column.resource.id)}
 						<div
 							bind:this={flowColumns[columnIndex]}
@@ -1153,6 +1344,7 @@
 				<footer
 					class="license-grid grid text-xs text-stone-500 dark:text-stone-400"
 					style="--columns: {visibleColumnCount}"
+					style:--column-track={columnTrack}
 				>
 					{#each data.columns as column (column.resource.id)}
 						<div class:hidden-on-mobile={column.index !== mobileColumn}>
@@ -1178,6 +1370,7 @@
 						<div
 							class="verse-grid"
 							style="--columns: {visibleColumnCount}"
+							style:--column-track={columnTrack}
 							data-mobile-column={mobileColumn}
 						>
 							{#if data.notesVisible}
@@ -1369,6 +1562,7 @@
 						<footer
 							class="license-grid grid text-xs text-stone-500 dark:text-stone-400"
 							style="--columns: {visibleColumnCount}"
+							style:--column-track={columnTrack}
 						>
 							{#each data.columns as column (column.resource.id)}
 								<div class:hidden-on-mobile={column.index !== mobileColumn}>
@@ -1410,7 +1604,7 @@
 <style>
 	.verse-grid {
 		display: grid;
-		grid-template-columns: repeat(var(--columns), minmax(0, 1fr));
+		grid-template-columns: var(--column-track, repeat(var(--columns), minmax(0, 1fr)));
 		column-gap: 0;
 		align-items: start;
 		border-radius: 0.5rem;
@@ -1422,8 +1616,31 @@
 		background: rgb(28 25 23 / 0.28);
 	}
 
+	/* Sits on top of the column-picker bar, straddling the boundary between two columns. Only the
+	   thin strip itself takes pointer events — see the wrapper's `pointer-events-none` in the markup. */
+	.column-resize-handle {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 10px;
+		margin-left: -5px;
+		cursor: col-resize;
+		touch-action: none;
+		pointer-events: auto;
+	}
+
+	.column-resize-handle:hover,
+	.column-resize-handle:focus-visible {
+		background: color-mix(in oklab, var(--color-accent-500) 35%, transparent);
+	}
+
+	.column-resize-handle:focus-visible {
+		outline: 2px solid var(--color-accent-500);
+		outline-offset: -2px;
+	}
+
 	.license-grid {
-		grid-template-columns: repeat(var(--columns), minmax(0, 1fr));
+		grid-template-columns: var(--column-track, repeat(var(--columns), minmax(0, 1fr)));
 		margin-top: 1.5rem;
 	}
 
@@ -1453,7 +1670,7 @@
 
 	.flow-reader {
 		display: grid;
-		grid-template-columns: repeat(var(--columns), minmax(0, 1fr));
+		grid-template-columns: var(--column-track, repeat(var(--columns), minmax(0, 1fr)));
 		height: max(28rem, calc(100dvh - var(--header-height) - 11.5rem));
 		overflow: hidden;
 		border: 1px solid color-mix(in oklab, var(--color-stone-300) 55%, transparent);

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -285,7 +285,15 @@
 	let jumpedSignature = '';
 	let suppressFlowScroll = false;
 	let suppressFlowTimer: ReturnType<typeof setTimeout> | undefined;
-	let suppressReaderScroll = false;
+	/**
+	 * How many in-flight programmatic scrolls are currently suppressing `onReaderWindowScroll`.
+	 *
+	 * A depth counter rather than a boolean: `loadAlignedPrevious`'s compensating `scrollBy` and a
+	 * `scrollToVerse` jump can overlap (a deep link landing while a background prepend is still
+	 * settling), and a boolean cleared by the first one to finish would let the second one's own
+	 * scroll events leak through as if the reader had scrolled.
+	 */
+	let suppressReaderScrollDepth = 0;
 	let flowSyncTimer: ReturnType<typeof setTimeout> | undefined;
 	/**
 	 * The element each flow column was last aligned to, indexed by column. A ranged block (a comment
@@ -335,7 +343,13 @@
 				// mistaken by `onReaderWindowScroll` for the reader having scrolled near the top of an
 				// accumulated stream — that would immediately prepend the previous chapter and scroll
 				// back down again, undoing the reset.
-				suppressProgrammaticReaderScroll();
+				//
+				// Only worth suppressing when the reset actually moves anything: a fresh page load is
+				// already at the top, so `scrollTo({ top: 0 })` causes no scroll event at all — nothing
+				// would ever clear the suppression except its timeout fallback, which would then blanket
+				// a real scroll the reader makes moments later (e.g. clicking straight into the next
+				// chapter) for no reason.
+				if (window.scrollY !== 0) suppressProgrammaticReaderScroll();
 				tick().then(() => window.scrollTo({ top: 0, behavior: 'instant' }));
 			}
 			if (data.readerLayout === 'aligned') {
@@ -355,18 +369,27 @@
 	}
 
 	/**
-	 * Suppresses `onReaderWindowScroll` for the one scroll event our own `window.scrollTo` reset
-	 * causes, the same way `suppressProgrammaticFlowScroll` shields the flow columns from their own
-	 * sync. Two animation frames comfortably span the async scroll event a browser dispatches after
-	 * `scrollTo`.
+	 * Suppresses `onReaderWindowScroll` for the one scroll our own code is about to cause — a
+	 * `window.scrollTo`/`scrollIntoView` reset, or `loadAlignedPrevious`'s compensating `scrollBy` —
+	 * the same way `suppressProgrammaticFlowScroll` shields the flow columns from their own sync.
+	 *
+	 * Cleared by the `scrollend` event, which is the actual "scroll has settled" signal rather than a
+	 * fixed number of animation frames (a timing guess that does not scale to momentum scrolling on
+	 * touch, where the browser keeps dispatching scroll events well past two frames). A `setTimeout`
+	 * fallback covers browsers that do not fire `scrollend` yet.
 	 */
 	function suppressProgrammaticReaderScroll() {
-		suppressReaderScroll = true;
-		requestAnimationFrame(() => {
-			requestAnimationFrame(() => {
-				suppressReaderScroll = false;
-			});
-		});
+		suppressReaderScrollDepth += 1;
+		let settled = false;
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(fallback);
+			window.removeEventListener('scrollend', finish);
+			suppressReaderScrollDepth = Math.max(0, suppressReaderScrollDepth - 1);
+		};
+		window.addEventListener('scrollend', finish, { once: true });
+		const fallback = setTimeout(finish, 400);
 	}
 
 	async function fetchStreamChapter(reference: { book: number; chapter: number }) {
@@ -417,6 +440,7 @@
 		try {
 			streamChapters.unshift(await fetchStreamChapter(reference));
 			await tick();
+			suppressProgrammaticReaderScroll();
 			window.scrollBy(0, document.documentElement.scrollHeight - oldHeight);
 		} finally {
 			loadingPrevious = false;
@@ -443,7 +467,7 @@
 	 */
 	function onReaderWindowScroll() {
 		if (data.readerLayout !== 'aligned') return;
-		if (suppressReaderScroll) return;
+		if (suppressReaderScrollDepth > 0) return;
 		if (window.scrollY < 500) void loadAlignedPrevious();
 		if (document.documentElement.scrollHeight - window.scrollY - window.innerHeight < 900) {
 			void loadAlignedNext();
@@ -575,6 +599,7 @@
 			document.querySelector<HTMLElement>(`[data-verse-key="${key}"]`) ??
 			(allowHighlightedFallback ? document.querySelector<HTMLElement>('.verse.highlighted') : null);
 		if (!target) return false;
+		suppressProgrammaticReaderScroll();
 		target.scrollIntoView({ block: 'start' });
 		scheduleAddressBarUpdate(key);
 		return true;


### PR DESCRIPTION
## Summary

Bündelt vier zusammenhängende todo.md-Punkte, die alle dieselbe Reader-Datei betreffen:

- **#1 Scroll-Jump-Fix**: Beim ersten Scrollen nach Reload sprang die Seite manchmal (v. a. Touch). Ursache war unvollständige Suppression programmatischer Scrolls im aligned-Layout (`scrollToVerse`, `loadAlignedPrevious`). Der Suppression-Mechanismus wurde von einer zeitbasierten Bool-Variable (zwei `requestAnimationFrame`s) auf einen re-entranten Zähler umgestellt, der erst nach dem `scrollend`-Event (mit Timeout-Fallback) zurückgesetzt wird.
- **#6 Auto-Scroll-Toggle pro Spalte**: Neuer Ein-/Ausschalter im Flow-Layout, ob eine Spalte an der Cross-Column-Scroll-Synchronisation teilnimmt. Persistiert id-basiert in einem eigenen Cookie.
- **#4 Spalten per Drag'n'Drop resizable**: Neue `--column-track`-CSS-Variable mit Fallback, Drag-Handles (`role="separator"`, tastaturbedienbar) zwischen den Spalten, Persistenz id-basiert, Mobile bleibt unberührt (bestehende Media-Query greift weiterhin).
- **#7 Echtes Tab-Design**: Der mobile Spaltenumschalter hat jetzt echte ARIA-Tab-Semantik (`role="tablist"/"tab"`, `aria-selected`, Pfeiltasten-Navigation), ohne Desktop-Screenreader-Nutzer versehentlich zu beeinträchtigen.

## Test plan

- [x] `pnpm check` — 0 Fehler
- [x] `pnpm lint` — clean
- [x] `pnpm test:e2e` — 70/71 (1 vorbestehender Skip, unabhängig von dieser Änderung), zweimal grün gelaufen
- [ ] Manueller Check auf einem echten Touch-Gerät (Scroll-Jump-Fix lässt sich in Playwright nur teilweise reproduzieren)

🤖 Generated with [Claude Code](https://claude.com/claude-code)