### PR TITLE
Auto-link Bible references and abbreviations in commentary text

### DIFF
--- a/src/lib/bible/auto-link.test.ts
+++ b/src/lib/bible/auto-link.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { autoLinkProse } from './auto-link.ts';
+
+describe('autoLinkProse', () => {
+	it('links a simple comma-separated reference in a sentence', () => {
+		expect(autoLinkProse('Siehe Joh 3,16 für mehr.')).toBe(
+			'Siehe <a class="verse-ref" href="/Joh3,16" data-book="43" data-chapter="3" data-verse="16">Joh 3,16</a> für mehr.'
+		);
+	});
+
+	it('links a colon-separated reference with a verse range', () => {
+		expect(autoLinkProse('Vgl. Mt 5:3-4.')).toBe(
+			'Vgl. <a class="verse-ref" href="/Mt5,3-4" data-book="40" data-chapter="5" data-verse="3" data-verse-end="4">Mt 5:3-4</a>.'
+		);
+	});
+
+	it('links a bare continuation reference that repeats the preceding book', () => {
+		expect(autoLinkProse('Joh 3,16; 4,2 sind bekannt.')).toBe(
+			'<a class="verse-ref" href="/Joh3,16" data-book="43" data-chapter="3" data-verse="16">Joh 3,16</a>; ' +
+				'<a class="verse-ref" href="/Joh4,2" data-book="43" data-chapter="4" data-verse="2">4,2</a> sind bekannt.'
+		);
+	});
+
+	it('does not continue the reference across an unrelated word', () => {
+		expect(autoLinkProse('Joh 3,16 und 4,2 sind bekannt.')).toBe(
+			'<a class="verse-ref" href="/Joh3,16" data-book="43" data-chapter="3" data-verse="16">Joh 3,16</a> und 4,2 sind bekannt.'
+		);
+	});
+
+	it('leaves plain text with no reference untouched', () => {
+		const text = 'Dies ist ein ganz normaler Satz ohne jede Bibelstelle.';
+		expect(autoLinkProse(text)).toBe(text);
+	});
+
+	it('does not mistake the book abbreviation "Mal" for the German filler word "mal"', () => {
+		const text = 'Ich war mal in der Stadt und habe nichts Besonderes erlebt.';
+		expect(autoLinkProse(text)).toBe(text);
+	});
+
+	it('does not mistake the book abbreviation "Ex" for the Latin word "ex" without a verse-shaped follow-up', () => {
+		const text = 'Das Modell entsteht ex nihilo, ohne Vorbedingung.';
+		expect(autoLinkProse(text)).toBe(text);
+	});
+
+	it('does link "Ex" when it is genuinely followed by a chapter,verse token', () => {
+		expect(autoLinkProse('Siehe Ex 3,14 zur Selbstoffenbarung Gottes.')).toBe(
+			'Siehe <a class="verse-ref" href="/2Mo3,14" data-book="2" data-chapter="3" data-verse="14">Ex 3,14</a> zur Selbstoffenbarung Gottes.'
+		);
+	});
+
+	it('only matches inside text nodes and leaves surrounding tags and structure intact', () => {
+		expect(autoLinkProse('<p>Text mit <em>Joh 3,16</em> Verweis.</p>')).toBe(
+			'<p>Text mit <em><a class="verse-ref" href="/Joh3,16" data-book="43" data-chapter="3" data-verse="16">Joh 3,16</a></em> Verweis.</p>'
+		);
+	});
+
+	it('does not nest a new link inside an existing <a> element', () => {
+		const html = '<p>Siehe <a href="/Joh3,16">Joh 3,16</a> für mehr.</p>';
+		expect(autoLinkProse(html)).toBe(html);
+	});
+
+	it('does not nest a new link inside an existing <abbr> element', () => {
+		const html = '<p>Vgl. <abbr title="Sinngemäß">Joh 3,16</abbr> weiter unten.</p>';
+		expect(autoLinkProse(html)).toBe(html);
+	});
+
+	it('resumes normal scanning for text after a closed <a> element', () => {
+		const html = '<a href="/Joh3,16">Joh 3,16</a> und außerdem Mt 5,3.';
+		expect(autoLinkProse(html)).toBe(
+			'<a href="/Joh3,16">Joh 3,16</a> und außerdem ' +
+				'<a class="verse-ref" href="/Mt5,3" data-book="40" data-chapter="5" data-verse="3">Mt 5,3</a>.'
+		);
+	});
+});

--- a/src/lib/bible/auto-link.ts
+++ b/src/lib/bible/auto-link.ts
@@ -1,0 +1,171 @@
+/**
+ * Runtime auto-linking of Bible references quoted inside already-sanitised HTML prose (commentary
+ * bodies today; potentially other freeform text later).
+ *
+ * `src/lib/bible/parse/strongs-xml.ts` already turns a lexicon source's explicit `<verseref>` tags
+ * into `<a class="verse-ref" data-book=… data-chapter=… data-verse=… data-verse-end=…>` links that
+ * `verseHoverPopover` (`src/lib/actions/verse-hover-popover.ts`) knows how to show a hover popup for —
+ * but that only covers sources that already mark references up explicitly. Free text (a commentary
+ * body, say) never does, so nothing there ever gets linked or hovered.
+ *
+ * This module finds references the same way `scanVerseReferences` in
+ * `scripts/convert-kautz-lexicon.ts` does for that offline conversion — token by token, requiring a
+ * *known* book abbreviation (via {@link findBookId}) immediately followed by a verse-shaped token, so
+ * ordinary prose containing a word that also happens to be a book abbreviation ("Mal", "Ex", "mal" as
+ * the German filler word) is not mistaken for a citation — and emits the exact same `<a class=
+ * "verse-ref" …>` markup `strongs-xml.ts` does, so `verseHoverPopover` needs no changes to pick these
+ * up wherever this function's output ends up in the DOM.
+ *
+ * Two differences from the Kautz script's version, both because this runs over this app's own prose
+ * rather than Kautz' English-styled source text:
+ *
+ *  - Both `,` and `:` are accepted between chapter and verse (this app's own reference grammar,
+ *    {@link import('./reference.ts').parseReference}, accepts either; German prose almost always
+ *    uses the comma, e.g. "Joh 3,16").
+ *  - Comma/dot-separated verse *lists* ("2:1,8,12,18") are not supported — this app's `VerseRef` only
+ *    models a single verse or a single `a-b` range, so neither does this.
+ *
+ * Safety: this only ever matches inside text nodes. `html` is split on tag boundaries before any
+ * reference scanning happens, so a match can never occur inside a tag name or attribute, and text
+ * already inside an `<a>` or `<abbr>` element is left alone rather than wrapped in a second, nested
+ * link — so running this on HTML that already carries reference links (or calling it twice) is safe.
+ * It assumes `html` is otherwise *safe* — sanitised, or limited to a small set of attribute-less tags
+ * the way `sanitizeHtml` in `parse/commentary.ts` produces — it does no sanitising of its own.
+ */
+
+import { findBookId } from './book-names.ts';
+import { referencePath } from './reference.ts';
+
+/** Matches a `chapter,verse[-verseEnd]` or `chapter:verse[-verseEnd]` token, e.g. "3,16" or "5:3-4". */
+const VERSE_TOKEN = /^(\d{1,3})[,:](\d{1,3})(?:-(\d{1,3}))?$/;
+
+/** Splits a string on HTML tag boundaries, keeping the tags themselves as their own array elements. */
+const TAG_SPLIT = /(<[a-zA-Z/][^>]*>)/g;
+
+/** Elements a reference link must never be nested inside — each already is (or contains) one. */
+const NO_NEST_TAGS = new Set(['a', 'abbr']);
+
+/** Splits trailing punctuation (closing parens, sentence stops) off a word so the core can be matched. */
+function stripTrailingPunctuation(word: string): { core: string; suffix: string } {
+	const match = /^(.*?)([.,;:)\]]*)$/.exec(word)!;
+	return { core: match[1]!, suffix: match[2]! };
+}
+
+function escapeAttr(value: string): string {
+	return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+}
+
+/** Renders one reference as the same `<a class="verse-ref" …>` markup `strongs-xml.ts` emits for a
+ *  `<verseref>` tag, so `verseHoverPopover` treats the two identically. `label` is the original
+ *  matched text verbatim (comma or colon, whatever the source used), not a reformatted version. */
+function renderVerseLink(
+	book: number,
+	chapter: number,
+	verse: number,
+	verseEnd: number | undefined,
+	label: string
+): string {
+	const href = referencePath({ book, chapter, verse, ...(verseEnd ? { verseEnd } : {}) });
+	const attrs = [
+		`href="${escapeAttr(href)}"`,
+		`data-book="${book}"`,
+		`data-chapter="${chapter}"`,
+		`data-verse="${verse}"`,
+		verseEnd ? `data-verse-end="${verseEnd}"` : ''
+	]
+		.filter(Boolean)
+		.join(' ');
+	return `<a class="verse-ref" ${attrs}>${label}</a>`;
+}
+
+/**
+ * Scans one run of plain text (no markup) for Bible references, linking each one found. Mirrors
+ * `scanVerseReferences` in `scripts/convert-kautz-lexicon.ts`: a token only starts a reference when it
+ * matches a known book abbreviation *and* the following token is verse-shaped, and a later bare
+ * verse-shaped token (e.g. "4,2" on its own, after "Joh 3,16") continues the same book without
+ * repeating its name — the common German citation style "Joh 3,16; 4,2".
+ *
+ * `book` carries the "current book" across calls for the same logical run of text (i.e. across
+ * `autoLinkProse`'s tag-boundary splits), the same way the module-level state does in the script this
+ * is ported from.
+ */
+function linkVerseReferences(text: string, book: { current: number | undefined }): string {
+	const parts = text.match(/\S+|\s+/g) ?? [];
+	let out = '';
+
+	for (let i = 0; i < parts.length; i += 1) {
+		const part = parts[i]!;
+		if (/^\s/.test(part)) {
+			out += part;
+			continue;
+		}
+
+		const bookId = findBookId(part);
+		const afterSpace = parts[i + 1];
+		const lookaheadWord = afterSpace && /^\s/.test(afterSpace) ? parts[i + 2] : undefined;
+		const lookahead = lookaheadWord ? stripTrailingPunctuation(lookaheadWord) : undefined;
+		const verseMatch = bookId !== undefined && lookahead ? VERSE_TOKEN.exec(lookahead.core) : null;
+
+		if (bookId !== undefined && verseMatch) {
+			book.current = bookId;
+			const chapter = Number.parseInt(verseMatch[1]!, 10);
+			const verse = Number.parseInt(verseMatch[2]!, 10);
+			const verseEnd = verseMatch[3] ? Number.parseInt(verseMatch[3], 10) : undefined;
+			const label = part + afterSpace + lookahead!.core;
+			out += renderVerseLink(bookId, chapter, verse, verseEnd, label) + lookahead!.suffix;
+			i += 2;
+			continue;
+		}
+
+		const { core, suffix } = stripTrailingPunctuation(part);
+		const bareMatch = VERSE_TOKEN.exec(core);
+		if (bareMatch && book.current !== undefined) {
+			const chapter = Number.parseInt(bareMatch[1]!, 10);
+			const verse = Number.parseInt(bareMatch[2]!, 10);
+			const verseEnd = bareMatch[3] ? Number.parseInt(bareMatch[3], 10) : undefined;
+			out += renderVerseLink(book.current, chapter, verse, verseEnd, core) + suffix;
+			continue;
+		}
+
+		book.current = undefined;
+		out += part;
+	}
+
+	return out;
+}
+
+/**
+ * Auto-links Bible references found in running HTML text (e.g. "Joh 3,16" or "Mt 5:3-4") into
+ * hoverable, clickable `verse-ref` links — see the module doc comment above for the matching rules
+ * and the safety guarantees around existing markup.
+ */
+export function autoLinkProse(html: string): string {
+	const parts = html.split(TAG_SPLIT);
+	const book: { current: number | undefined } = { current: undefined };
+	let skipDepth = 0;
+	let out = '';
+
+	for (const part of parts) {
+		if (!part) continue;
+
+		const tagMatch = /^<(\/?)([a-zA-Z][\w-]*)/.exec(part);
+		if (tagMatch) {
+			const [, slash, name] = tagMatch;
+			if (NO_NEST_TAGS.has(name!.toLowerCase())) {
+				skipDepth = Math.max(0, skipDepth + (slash ? -1 : 1));
+				book.current = undefined;
+			}
+			out += part;
+			continue;
+		}
+
+		if (skipDepth > 0) {
+			out += part;
+			continue;
+		}
+
+		out += linkVerseReferences(part, book);
+	}
+
+	return out;
+}

--- a/src/lib/bible/parse/commentary.ts
+++ b/src/lib/bible/parse/commentary.ts
@@ -20,6 +20,7 @@
  */
 
 import { parseReference } from '../reference.ts';
+import { autoLinkProse } from '../auto-link.ts';
 import { attribute, readXml } from './xml.ts';
 import { splitDelimited } from './detect.ts';
 import { readLines } from './usfm.ts';
@@ -366,7 +367,9 @@ const KEEP_TAGS = new Set(['p', 'br', 'em', 'i', 'strong', 'b', 'ul', 'ol', 'li'
  * Reduces an untrusted body to plain text plus a small set of formatting tags.
  *
  * Everything is escaped first and only the allowed tags are put back, so no attribute — and therefore
- * no event handler, style or URL — survives from the source.
+ * no event handler, style or URL — survives from the source. Bible references mentioned in the text
+ * are auto-linked last, once the result is already safe, limited-tag HTML that {@link autoLinkProse}
+ * can scan without risking any markup it does not already know how to leave alone.
  */
 export function sanitizeHtml(value: string): string {
 	const escaped = escapeHtml(stripTags(value));
@@ -375,14 +378,14 @@ export function sanitizeHtml(value: string): string {
 		(_match, slash: string, tag: string) => `<${slash}${tag.toLowerCase()}>`
 	);
 
-	return (
-		withTags
-			// Markdown-style emphasis is common in hand-written commentary files.
-			.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-			.replace(/(^|\s)\*([^*]+)\*/g, '$1<em>$2</em>')
-			.replace(/\s+/g, ' ')
-			.trim()
-	);
+	const rendered = withTags
+		// Markdown-style emphasis is common in hand-written commentary files.
+		.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+		.replace(/(^|\s)\*([^*]+)\*/g, '$1<em>$2</em>')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	return autoLinkProse(rendered);
 }
 
 /** Removes tags that are not in the allow list, keeping their text content. */

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -7,6 +7,7 @@
 	import { formatReference, referencePath, type VerseRef } from '$lib/bible/reference';
 	import { segmentsToText, splitVerseLead } from '$lib/bible/segments';
 	import { readerLocation, setJumpToVerse } from '$lib/reader-location.svelte';
+	import { verseHoverPopover } from '$lib/actions/verse-hover-popover';
 	import { t } from '$lib/i18n';
 	import ColumnPicker from '$lib/components/ColumnPicker.svelte';
 	import Menu from '$lib/components/Menu.svelte';
@@ -45,6 +46,13 @@
 
 	let verseMenu = $state<VerseMenu | undefined>();
 	let addColumnMenu = $state<Menu | undefined>();
+
+	/** The translation the commentary auto-link popover fetches verse text from: whichever Bible
+	 *  translation is actually showing in a column right now, so hovering a reference in a commentary
+	 *  shows the same text the reader is already reading, not some other fixed pick. */
+	const primaryBibleId = $derived(
+		data.columns.find((column) => column.resource.kind === 'bible')?.resource.id ?? null
+	);
 
 	const unusedResources = $derived(
 		data.readerResources.filter(
@@ -1041,8 +1049,13 @@
 													{#each entries as entry (entry.id)}
 														{#if entry.title}<h3 class="commentary-title">{entry.title}</h3>{/if}
 														<!-- Imported commentary is reduced to an allow-list by its parser. -->
-														<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-														<div class="commentary-body">{@html entry.bodyHtml}</div>
+														<div
+															class="commentary-body"
+															use:verseHoverPopover={{ bibleId: primaryBibleId }}
+														>
+															<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+															{@html entry.bodyHtml}
+														</div>
 													{/each}
 												</article>
 											{/if}
@@ -1271,8 +1284,13 @@
 														<h3 class="commentary-title">{entry.title}</h3>
 													{/if}
 													<!-- Imported commentary is reduced to an allow-list by its parser. -->
-													<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-													<div class="commentary-body">{@html entry.bodyHtml}</div>
+													<div
+														class="commentary-body"
+														use:verseHoverPopover={{ bibleId: primaryBibleId }}
+													>
+														<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+														{@html entry.bodyHtml}
+													</div>
 												{/each}
 											</article>
 										{/if}


### PR DESCRIPTION
## Summary

Todo.md #2: "Auch in Kommentaren und Bibeltexten Stellen automatisch erkennen und Mausover bzw. Link anzeigen, so wie in den Strong-Kommentaren."

- Neues Runtime-Modul `src/lib/bible/auto-link.ts` (`autoLinkProse()`), portiert aus dem bisher offline-only Scanner in `scripts/convert-kautz-lexicon.ts`. Erkennt Bibelstellen (`Buch Kapitel,Vers[-Ende]`, inkl. Fortsetzungszitate) in freiem HTML-Text und verpackt sie im selben `<a class="verse-ref" data-book=… data-chapter=… data-verse=…>`-Markup, das die Lexikon-Einträge bereits nutzen — inklusive Wortgrenzen-Schutz gegen False Positives ("mal", "Ex" als normale Wörter).
- Eingebunden als letzter Schritt in `commentary.ts`s `sanitizeHtml()`, sodass Kommentar-`bodyHtml` bereits verlinktes Markup enthält.
- `use:verseHoverPopover` an beiden Kommentar-Render-Stellen in `+page.svelte` ergänzt (Flow- und Aligned-Layout) — dieselbe Mausover-Vorschau, die es im Lexikon schon gibt.

**Bewusst ausgeklammert:** Bibeltext selbst (`VerseText.svelte`) rendert aus strukturierten `VerseSegment[]`-Daten, nicht via `{@html}` — es gibt dort keinen HTML-Einspeisungspunkt für den Scanner. Automatische Verlinkung innerhalb des Bibeltexts selbst (z. B. wenn ein Vers eine andere Stelle zitiert) bräuchte einen eigenen, auf `VerseSegment[]` arbeitenden Ansatz und ist ein möglicher Folge-Task.

## Test plan

- [x] `pnpm check` — 0 Fehler
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 327/334 (die 7 abweichenden `backup/crypto.spec.ts`-Tests sind vorbestehend/umgebungsbedingt, gegen unveränderten Branch verifiziert)
- [x] `pnpm test:e2e` — 66/67 (1 vorbestehender Skip)
- [x] 12 neue Unit-Tests für `autoLinkProse()` (Wortgrenzen, Fortsetzungszitate, keine Doppelverschachtelung in bestehende Tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)