### PR TITLE
Require email activation for registration, add honeypot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm run check
-      # Unit tests need no database: the domain layer and the parsers do no I/O.
+      # Most unit tests need no database, but the activation-token repository tests exercise real
+      # queries against the schema, so migrations still have to run against the service above.
+      - run: pnpm run db:migrate
       - run: pnpm run test:unit --run
 
   e2e:

--- a/drizzle/0012_sturdy_golden_guardian.sql
+++ b/drizzle/0012_sturdy_golden_guardian.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "email_verifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "email_verifications" ADD CONSTRAINT "email_verifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "email_verifications_user_idx" ON "email_verifications" USING btree ("user_id");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2450 @@
+{
+  "id": "4e502a90-2af8-4d4c-9dd6-e38699c51f5f",
+  "prevId": "650b1fc8-8456-4669-98ba-02a3c328baf7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_idx": {
+          "name": "api_keys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_requests": {
+      "name": "api_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_requests_subject_idx": {
+          "name": "api_requests_subject_idx",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_jobs": {
+      "name": "backup_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "backup_jobs_state_idx": {
+          "name": "backup_jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_jobs_type_idx": {
+          "name": "backup_jobs_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backup_jobs_created_by_users_id_fk": {
+          "name": "backup_jobs_created_by_users_id_fk",
+          "tableFrom": "backup_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_notes": {
+      "name": "chapter_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_html": {
+          "name": "note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chapter_notes_reference_idx": {
+          "name": "chapter_notes_reference_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chapter_notes_user_idx": {
+          "name": "chapter_notes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chapter_notes_user_id_users_id_fk": {
+          "name": "chapter_notes_user_id_users_id_fk",
+          "tableFrom": "chapter_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chapter_notes_book_id_check": {
+          "name": "chapter_notes_book_id_check",
+          "value": "\"chapter_notes\".\"book_id\" between 1 and 66"
+        },
+        "chapter_notes_chapter_check": {
+          "name": "chapter_notes_chapter_check",
+          "value": "\"chapter_notes\".\"chapter\" between 1 and 200"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commentary_entries": {
+      "name": "commentary_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_start": {
+          "name": "verse_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_end": {
+          "name": "verse_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "commentary_entries_ref_idx": {
+          "name": "commentary_entries_ref_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commentary_entries_resource_id_resources_id_fk": {
+          "name": "commentary_entries_resource_id_resources_id_fk",
+          "tableFrom": "commentary_entries",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cross_references": {
+      "name": "cross_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_book": {
+          "name": "from_book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_chapter": {
+          "name": "from_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_verse": {
+          "name": "from_verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_book": {
+          "name": "to_book",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_chapter": {
+          "name": "to_chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_verse": {
+          "name": "to_verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_verse_end": {
+          "name": "to_verse_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes": {
+          "name": "votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "cross_references_from_idx": {
+          "name": "cross_references_from_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_book",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cross_references_resource_id_resources_id_fk": {
+          "name": "cross_references_resource_id_resources_id_fk",
+          "tableFrom": "cross_references",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verifications": {
+      "name": "email_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verifications_user_idx": {
+          "name": "email_verifications_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verifications_user_id_users_id_fk": {
+          "name": "email_verifications_user_id_users_id_fk",
+          "tableFrom": "email_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.highlight_styles": {
+      "name": "highlight_styles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'color'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "highlight_styles_user_idx": {
+          "name": "highlight_styles_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "highlight_styles_user_id_users_id_fk": {
+          "name": "highlight_styles_user_id_users_id_fk",
+          "tableFrom": "highlight_styles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_jobs": {
+      "name": "import_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_format": {
+          "name": "source_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "import_jobs_state_idx": {
+          "name": "import_jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "import_jobs_created_by_users_id_fk": {
+          "name": "import_jobs_created_by_users_id_fk",
+          "tableFrom": "import_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lexicon_entries": {
+      "name": "lexicon_entries",
+      "schema": "",
+      "columns": {
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strong": {
+          "name": "strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transliteration": {
+          "name": "transliteration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pronunciation": {
+          "name": "pronunciation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_html": {
+          "name": "definition_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derivation_html": {
+          "name": "derivation_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kjv_definition_html": {
+          "name": "kjv_definition_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "see_also": {
+          "name": "see_also",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        }
+      },
+      "indexes": {
+        "lexicon_entries_strong_idx": {
+          "name": "lexicon_entries_strong_idx",
+          "columns": [
+            {
+              "expression": "strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lexicon_entries_resource_id_resources_id_fk": {
+          "name": "lexicon_entries_resource_id_resources_id_fk",
+          "tableFrom": "lexicon_entries",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "lexicon_entries_resource_id_strong_pk": {
+          "name": "lexicon_entries_resource_id_strong_pk",
+          "columns": [
+            "resource_id",
+            "strong"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_attempts": {
+      "name": "login_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "login_attempts_subject_idx": {
+          "name": "login_attempts_subject_idx",
+          "columns": [
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_resets": {
+      "name": "password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_resets_user_idx": {
+          "name": "password_resets_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_resets_user_id_users_id_fk": {
+          "name": "password_resets_user_id_users_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_books": {
+      "name": "resource_books",
+      "schema": "",
+      "columns": {
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_count": {
+          "name": "chapter_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_count": {
+          "name": "verse_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_books_resource_id_resources_id_fk": {
+          "name": "resource_books_resource_id_resources_id_fk",
+          "tableFrom": "resource_books",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "resource_books_resource_id_book_id_pk": {
+          "name": "resource_books_resource_id_book_id_pk",
+          "columns": [
+            "resource_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_books_book_id_check": {
+          "name": "resource_books_book_id_check",
+          "value": "\"resource_books\".\"book_id\" between 1 and 66"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbrev": {
+          "name": "abbrev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canon": {
+          "name": "canon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'both'"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ltr'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_strongs": {
+          "name": "has_strongs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_morphology": {
+          "name": "has_morphology",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "license_html": {
+          "name": "license_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_format": {
+          "name": "source_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verse_count": {
+          "name": "verse_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_kind_public_idx": {
+          "name": "resources_kind_public_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resources_sort_order_check": {
+          "name": "resources_sort_order_check",
+          "value": "\"resources\".\"sort_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_user_idx": {
+          "name": "sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_columns": {
+          "name": "reader_columns",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "reader_font_scale": {
+          "name": "reader_font_scale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "reader_layout": {
+          "name": "reader_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_reader_font_scale_check": {
+          "name": "users_reader_font_scale_check",
+          "value": "\"users\".\"reader_font_scale\" between 85 and 140"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verse_highlights": {
+      "name": "verse_highlights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "style_id": {
+          "name": "style_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_highlights_verse_idx": {
+          "name": "verse_highlights_verse_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verse_highlights_style_idx": {
+          "name": "verse_highlights_style_idx",
+          "columns": [
+            {
+              "expression": "style_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_highlights_user_id_users_id_fk": {
+          "name": "verse_highlights_user_id_users_id_fk",
+          "tableFrom": "verse_highlights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verse_highlights_style_id_highlight_styles_id_fk": {
+          "name": "verse_highlights_style_id_highlight_styles_id_fk",
+          "tableFrom": "verse_highlights",
+          "tableTo": "highlight_styles",
+          "columnsFrom": [
+            "style_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_list_items": {
+      "name": "verse_list_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "note_html": {
+          "name": "note_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_list_items_list_idx": {
+          "name": "verse_list_items_list_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verse_list_items_verse_idx": {
+          "name": "verse_list_items_verse_idx",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_list_items_list_id_verse_lists_id_fk": {
+          "name": "verse_list_items_list_id_verse_lists_id_fk",
+          "tableFrom": "verse_list_items",
+          "tableTo": "verse_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_lists": {
+      "name": "verse_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intro_html": {
+          "name": "intro_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verse_lists_user_idx": {
+          "name": "verse_lists_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verse_lists_slug_idx": {
+          "name": "verse_lists_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_lists_user_id_users_id_fk": {
+          "name": "verse_lists_user_id_users_id_fk",
+          "tableFrom": "verse_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verse_words": {
+      "name": "verse_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_id": {
+          "name": "verse_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strong": {
+          "name": "strong",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morph": {
+          "name": "morph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lemma": {
+          "name": "lemma",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "translit": {
+          "name": "translit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verse_words_strong_idx": {
+          "name": "verse_words_strong_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verse_words_verse_idx": {
+          "name": "verse_words_verse_idx",
+          "columns": [
+            {
+              "expression": "verse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verse_words_lookup_idx": {
+          "name": "verse_words_lookup_idx",
+          "columns": [
+            {
+              "expression": "strong",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verse_words_resource_id_resources_id_fk": {
+          "name": "verse_words_resource_id_resources_id_fk",
+          "tableFrom": "verse_words",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verse_words_verse_id_verses_id_fk": {
+          "name": "verse_words_verse_id_verses_id_fk",
+          "tableFrom": "verse_words",
+          "tableTo": "verses",
+          "columnsFrom": [
+            "verse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verses": {
+      "name": "verses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse": {
+          "name": "verse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verse_end": {
+          "name": "verse_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('german_unaccent', text)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "verses_ref_idx": {
+          "name": "verses_ref_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "verse",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verses_search_idx": {
+          "name": "verses_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verses_resource_id_resources_id_fk": {
+          "name": "verses_resource_id_resources_id_fk",
+          "tableFrom": "verses",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "verses_book_id_check": {
+          "name": "verses_book_id_check",
+          "value": "\"verses\".\"book_id\" between 1 and 66"
+        },
+        "verses_chapter_check": {
+          "name": "verses_chapter_check",
+          "value": "\"verses\".\"chapter\" between 1 and 200"
+        },
+        "verses_verse_check": {
+          "name": "verses_verse_check",
+          "value": "\"verses\".\"verse\" between 1 and 250"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785828010679,
       "tag": "0011_gorgeous_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785845433251,
+      "tag": "0012_sturdy_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/account.e2e.ts
+++ b/e2e/account.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { lastMailLinkTo } from './lib/mail-outbox.ts';
 
 /**
  * Accounts, verse lists and notes, and the admin area.
@@ -13,6 +14,12 @@ function uniqueEmail(): string {
 
 const PASSWORD = 'ein-sicheres-passwort';
 
+/**
+ * Registers an account and immediately follows the confirmation link, ending up signed in on
+ * `/account` — the same end state this helper had before registration required activation. Every
+ * other test in this file only cares about arriving there, not about the activation step itself
+ * (see register.e2e.ts for tests of that step).
+ */
 async function register(page: import('@playwright/test').Page, email: string): Promise<void> {
 	await page.goto('/register');
 	await page.getByLabel('E-Mail-Adresse').fill(email);
@@ -20,6 +27,10 @@ async function register(page: import('@playwright/test').Page, email: string): P
 	await page.getByLabel('Passwort', { exact: true }).fill(PASSWORD);
 	await page.getByLabel('Passwort wiederholen').fill(PASSWORD);
 	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await page.goto(await lastMailLinkTo(email));
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
 	await expect(page).toHaveURL(/\/account$/);
 }
 

--- a/e2e/admin-backup.e2e.ts
+++ b/e2e/admin-backup.e2e.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
+import { lastMailLinkTo } from './lib/mail-outbox.ts';
 
 /**
  * Admin backup and restore.
@@ -30,6 +31,10 @@ async function register(page: import('@playwright/test').Page, email: string): P
 	await page.getByLabel('Passwort', { exact: true }).fill(PASSWORD);
 	await page.getByLabel('Passwort wiederholen').fill(PASSWORD);
 	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await page.goto(await lastMailLinkTo(email));
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
 	await expect(page).toHaveURL(/\/account$/);
 }
 

--- a/e2e/api.e2e.ts
+++ b/e2e/api.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { lastMailLinkTo } from './lib/mail-outbox.ts';
 
 /**
  * The public API: the domain gate and rate limiting (`hooks.server.ts` + `lib/server/api/`), and the
@@ -20,12 +21,17 @@ async function registerAndCreateKey(
 	page: import('@playwright/test').Page,
 	scope: 'public' | 'personal'
 ): Promise<string> {
+	const email = uniqueEmail();
 	await page.goto('/register');
-	await page.getByLabel('E-Mail-Adresse').fill(uniqueEmail());
+	await page.getByLabel('E-Mail-Adresse').fill(email);
 	await page.getByLabel('Anzeigename').fill('E2E');
 	await page.getByLabel('Passwort', { exact: true }).fill('ein-sicheres-passwort');
 	await page.getByLabel('Passwort wiederholen').fill('ein-sicheres-passwort');
 	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await page.goto(await lastMailLinkTo(email));
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
 	await expect(page).toHaveURL(/\/account$/);
 
 	await page.getByLabel('Name', { exact: true }).fill(`E2E ${scope}`);
@@ -146,12 +152,17 @@ test('GET /api/v1/lists and /api/v1/notes need a session or a personal-scope key
 });
 
 test('a signed-in session reads its own lists and notes through the API', async ({ page }) => {
+	const email = uniqueEmail();
 	await page.goto('/register');
-	await page.getByLabel('E-Mail-Adresse').fill(uniqueEmail());
+	await page.getByLabel('E-Mail-Adresse').fill(email);
 	await page.getByLabel('Anzeigename').fill('E2E');
 	await page.getByLabel('Passwort', { exact: true }).fill('ein-sicheres-passwort');
 	await page.getByLabel('Passwort wiederholen').fill('ein-sicheres-passwort');
 	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await page.goto(await lastMailLinkTo(email));
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
 	await expect(page).toHaveURL(/\/account$/);
 
 	// A real in-page fetch, not the request fixture: only a browser attaches the session cookie and

--- a/e2e/lib/mail-outbox.ts
+++ b/e2e/lib/mail-outbox.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import { MAIL_TEST_OUTBOX } from '../../scripts/lib/mail-outbox.ts';
+
+type SentMail = { to: string; subject: string; text: string };
+
+/**
+ * Recovers the link from the most recent mail the app "sent" to `email`.
+ *
+ * Registration and password reset only ever store a token's hash, and e2e runs without a
+ * `BREVO_API_KEY`, so the app's `loggingMailer` never delivers anything — see the doc comment on
+ * `MAIL_TEST_OUTBOX` for why this file exists at all. Reads are polled briefly: the write is awaited
+ * server-side before the response is sent, but the two processes can still race by a beat.
+ */
+export async function lastMailLinkTo(email: string): Promise<string> {
+	for (let attempt = 0; attempt < 30; attempt++) {
+		const link = await findLink(email);
+		if (link) return link;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error(`no mail to ${email} appeared in the e2e outbox in time`);
+}
+
+async function findLink(email: string): Promise<string | null> {
+	let content: string;
+	try {
+		content = await readFile(MAIL_TEST_OUTBOX, 'utf8');
+	} catch {
+		return null;
+	}
+
+	const lines = content.split('\n').filter((line) => line.length > 0);
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const mail = JSON.parse(lines[i]) as SentMail;
+		if (mail.to !== email) continue;
+		const match = mail.text.match(/https?:\/\/\S+/);
+		if (match) return match[0];
+	}
+	return null;
+}

--- a/e2e/register.e2e.ts
+++ b/e2e/register.e2e.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+import { lastMailLinkTo } from './lib/mail-outbox.ts';
+
+/**
+ * Registration: activation by mail, and the honeypot that guards it.
+ *
+ * `account.e2e.ts` and `admin-backup.e2e.ts` have their own `register()` helper that already follows
+ * the confirmation link, so every other suite can keep assuming "registered" means "signed in". These
+ * tests are the ones that actually exercise the steps in between.
+ */
+
+function uniqueEmail(): string {
+	return `e2e-register-${Math.random().toString(36).slice(2, 10)}@example.com`;
+}
+
+const PASSWORD = 'ein-sicheres-passwort';
+
+async function fillRegisterForm(
+	page: import('@playwright/test').Page,
+	email: string
+): Promise<void> {
+	await page.goto('/register');
+	await page.getByLabel('E-Mail-Adresse').fill(email);
+	await page.getByLabel('Anzeigename').fill('E2E');
+	await page.getByLabel('Passwort', { exact: true }).fill(PASSWORD);
+	await page.getByLabel('Passwort wiederholen').fill(PASSWORD);
+}
+
+async function loginAsAdmin(page: import('@playwright/test').Page): Promise<void> {
+	// The seed script creates this account.
+	await page.goto('/login');
+	await page.getByLabel('E-Mail-Adresse').fill('admin@example.com');
+	await page.getByLabel('Passwort').fill('seed-admin-password');
+	await page.getByRole('button', { name: 'Anmelden' }).click();
+}
+
+test('registering does not sign in immediately', async ({ page }) => {
+	const email = uniqueEmail();
+	await fillRegisterForm(page, email);
+	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+	await expect(
+		page.getByRole('heading', { name: 'Bitte bestätige deine E-Mail-Adresse' })
+	).toBeVisible();
+
+	// No session was created, so the account area bounces straight to the login page.
+	await page.goto('/account');
+	await expect(page).toHaveURL(/\/login/);
+});
+
+test('confirming the activation link signs the account in', async ({ page }) => {
+	const email = uniqueEmail();
+	await fillRegisterForm(page, email);
+	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await page.goto(await lastMailLinkTo(email));
+	await expect(page.getByRole('heading', { name: 'Konto aktivieren' })).toBeVisible();
+
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
+	await expect(page).toHaveURL(/\/account$/);
+});
+
+test('an already-used activation link is rejected the second time', async ({ page }) => {
+	const email = uniqueEmail();
+	await fillRegisterForm(page, email);
+	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+
+	const link = await lastMailLinkTo(email);
+	await page.goto(link);
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
+	await expect(page).toHaveURL(/\/account$/);
+
+	await page.getByRole('button', { name: 'Abmelden' }).click();
+	await page.goto(link);
+	await expect(page.getByRole('alert')).toContainText('abgelaufen');
+});
+
+test('an unconfirmed account cannot sign in, but a fresh link works', async ({ page }) => {
+	const email = uniqueEmail();
+	await fillRegisterForm(page, email);
+	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	// The credentials are correct, but the account was never activated.
+	await page.goto('/login');
+	await page.getByLabel('E-Mail-Adresse').fill(email);
+	await page.getByLabel('Passwort').fill(PASSWORD);
+	await page.getByRole('button', { name: 'Anmelden' }).click();
+	await expect(page.getByRole('alert')).toContainText('bestätige');
+
+	await page.getByRole('button', { name: 'Aktivierungslink erneut senden' }).click();
+	await expect(page.getByText('ist eine neue E-Mail unterwegs')).toBeVisible();
+
+	// The resend mail is the newest one for this address, so this picks it up rather than the
+	// original registration mail.
+	await page.goto(await lastMailLinkTo(email));
+	await page.getByRole('button', { name: 'Konto aktivieren' }).click();
+	await expect(page).toHaveURL(/\/account$/);
+
+	await page.getByRole('button', { name: 'Abmelden' }).click();
+	await page.goto('/login');
+	await page.getByLabel('E-Mail-Adresse').fill(email);
+	await page.getByLabel('Passwort').fill(PASSWORD);
+	await page.getByRole('button', { name: 'Anmelden' }).click();
+	await expect(page).toHaveURL(/\/account$/);
+});
+
+test('a filled honeypot field is answered as success but creates no account', async ({ page }) => {
+	const email = uniqueEmail();
+	await fillRegisterForm(page, email);
+	// A real visitor can neither see nor tab to this field; a script that fills every input in the
+	// form does not know that.
+	await page.locator('input[name="company"]').fill('Acme Inc.');
+	await page.getByRole('button', { name: 'Konto erstellen' }).click();
+
+	// The bot is told it worked, exactly like a real registration.
+	await expect(page).toHaveURL(/\/register\/check-email$/);
+
+	await loginAsAdmin(page);
+	await page.goto('/admin/users');
+	await expect(page.getByText(email)).toHaveCount(0);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@playwright/test';
 import { testDatabaseUrl } from './scripts/lib/test-database.ts';
+import { MAIL_TEST_OUTBOX } from './scripts/lib/mail-outbox.ts';
 
 /**
  * End-to-end tests run against a production build, since that is what the container serves, and
@@ -34,7 +35,9 @@ export default defineConfig({
 			SESSION_SECRET: 'e2e-session-secret-e2e-session-secret-0123',
 			// Lets the backup tests exercise the encrypted S3-secret path, not just the unconfigured one.
 			BACKUP_ENCRYPTION_KEY: 'e2e-backup-encryption-key-0123456789abcdef',
-			NODE_ENV: 'production'
+			NODE_ENV: 'production',
+			// See scripts/lib/mail-outbox.ts: recovers verification/reset links the app "sends" via mail.
+			MAIL_TEST_OUTBOX: MAIL_TEST_OUTBOX
 		}
 	}
 });

--- a/scripts/lib/mail-outbox.ts
+++ b/scripts/lib/mail-outbox.ts
@@ -1,0 +1,13 @@
+/**
+ * Where the end-to-end mail outbox lives.
+ *
+ * A module of its own, free of side effects — same reasoning as `test-database.ts` — since
+ * `playwright.config.ts`, `scripts/prepare-e2e.ts` and the e2e specs themselves all need this path.
+ *
+ * Registration and password-reset send a real link by mail; with no `BREVO_API_KEY` configured for
+ * e2e, the app's `loggingMailer` never actually delivers it. Only the token's hash is ever stored in
+ * the database, so there is no way to recover the link from there either. Setting `MAIL_TEST_OUTBOX`
+ * to this path makes the app mirror every "sent" mail here as JSON lines, which the e2e specs read
+ * directly since the webServer they drive runs on the same host.
+ */
+export const MAIL_TEST_OUTBOX = './var/e2e-mail-outbox.jsonl';

--- a/scripts/prepare-e2e.ts
+++ b/scripts/prepare-e2e.ts
@@ -11,8 +11,10 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { rm } from 'node:fs/promises';
 import postgres from 'postgres';
 import { testDatabaseUrl } from './lib/test-database.ts';
+import { MAIL_TEST_OUTBOX } from './lib/mail-outbox.ts';
 
 const base = process.env.DATABASE_URL;
 if (!base) {
@@ -53,5 +55,9 @@ try {
 }
 
 execFileSync('node', ['scripts/seed.ts'], { stdio: 'inherit', env: environment });
+
+// Stale links from a previous run cannot match a fresh run's unique email addresses, but there is no
+// reason to let the file grow forever either.
+await rm(MAIL_TEST_OUTBOX, { force: true });
 
 console.log(`end-to-end database ready: ${targetName}`);

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -124,7 +124,9 @@ try {
 			email: SEED_ADMIN.email,
 			passwordHash: await hashPassword(SEED_ADMIN.password),
 			displayName: 'Seed Admin',
-			role: 'admin'
+			role: 'admin',
+			// Created directly, not through registration, so there is no activation link to click.
+			emailVerifiedAt: new Date()
 		});
 	}
 

--- a/src/lib/components/AuthForm.svelte
+++ b/src/lib/components/AuthForm.svelte
@@ -7,6 +7,7 @@
 		error = null,
 		notice = null,
 		submitLabel,
+		action = undefined,
 		children,
 		footer
 	}: {
@@ -14,6 +15,8 @@
 		error?: string | null;
 		notice?: string | null;
 		submitLabel: string;
+		/** Targets a named action (e.g. `?/login`) instead of the route's default one. */
+		action?: string;
 		children: Snippet;
 		footer?: Snippet;
 	} = $props();
@@ -47,7 +50,7 @@
 		</p>
 	{/if}
 
-	<form method="POST" class="space-y-4">
+	<form {action} method="POST" class="space-y-4">
 		{@render children()}
 
 		<button

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -166,11 +166,23 @@ export const de = {
 	'auth.login.submit': 'Anmelden',
 	'auth.login.failed': 'E-Mail-Adresse oder Passwort ist falsch.',
 	'auth.login.throttled': 'Zu viele Versuche. Bitte warte einen Moment.',
+	'auth.login.unverified': 'Bitte bestätige zuerst deine E-Mail-Adresse.',
 	'auth.register.title': 'Konto erstellen',
 	'auth.register.submit': 'Konto erstellen',
 	'auth.register.emailTaken': 'Für diese E-Mail-Adresse existiert bereits ein Konto.',
 	'auth.register.passwordMismatch': 'Die Passwörter stimmen nicht überein.',
 	'auth.register.passwordTooShort': 'Das Passwort muss mindestens {min} Zeichen lang sein.',
+	'auth.register.throttled': 'Zu viele Versuche. Bitte warte einen Moment.',
+	'auth.register.checkEmailTitle': 'Bitte bestätige deine E-Mail-Adresse',
+	'auth.register.checkEmailBody':
+		'Wir haben dir eine E-Mail mit einem Bestätigungslink geschickt. Öffne den Link, um dein Konto zu aktivieren.',
+	'auth.register.verifyTitle': 'Konto aktivieren',
+	'auth.register.verifyBody': 'Bestätige deine E-Mail-Adresse, um dein Konto zu aktivieren.',
+	'auth.register.verifySubmit': 'Konto aktivieren',
+	'auth.register.verifyInvalid': 'Dieser Link ist abgelaufen oder wurde bereits verwendet.',
+	'auth.register.resendVerification': 'Aktivierungslink erneut senden',
+	'auth.register.resendSent':
+		'Falls das Konto noch nicht aktiviert ist, ist eine neue E-Mail unterwegs.',
 	'auth.passwordReset.title': 'Passwort zurücksetzen',
 	'auth.passwordReset.submit': 'Link senden',
 	'auth.passwordReset.sent':

--- a/src/lib/server/auth/rate-limit.ts
+++ b/src/lib/server/auth/rate-limit.ts
@@ -71,6 +71,11 @@ export async function pruneLoginAttempts(db: Database): Promise<void> {
 /** Exported for tests, which need to know when the limit bites. */
 export const LIMITS = { WINDOW_MS, MAX_PER_EMAIL, MAX_PER_ADDRESS };
 
+/** Records a single attempt under an arbitrary subject, e.g. `register:<ip>`. */
+export async function recordAttempt(db: Database, subject: string): Promise<void> {
+	await db.insert(loginAttempts).values({ subject });
+}
+
 /** Used by the password-reset form, which is rate limited on the same table. */
 export async function countRecent(
 	db: Database,

--- a/src/lib/server/auth/rate-limit.ts
+++ b/src/lib/server/auth/rate-limit.ts
@@ -16,6 +16,13 @@ import { loginAttempts } from '../db/schema.ts';
 const WINDOW_MS = 15 * 60 * 1000;
 const MAX_PER_EMAIL = 8;
 const MAX_PER_ADDRESS = 30;
+/**
+ * Registration sees legitimately higher volume per address than a login failure or a password
+ * reset — several people signing up from behind the same office or campus NAT is normal, a script
+ * creating dozens of accounts a minute is not. Higher than `MAX_PER_ADDRESS`, still well below what
+ * scripted abuse needs to be a nuisance.
+ */
+const MAX_REGISTRATIONS_PER_ADDRESS = 50;
 
 export async function recordFailedLogin(
 	db: Database,
@@ -69,7 +76,12 @@ export async function pruneLoginAttempts(db: Database): Promise<void> {
 }
 
 /** Exported for tests, which need to know when the limit bites. */
-export const LIMITS = { WINDOW_MS, MAX_PER_EMAIL, MAX_PER_ADDRESS };
+export const LIMITS = {
+	WINDOW_MS,
+	MAX_PER_EMAIL,
+	MAX_PER_ADDRESS,
+	MAX_REGISTRATIONS_PER_ADDRESS
+};
 
 /** Records a single attempt under an arbitrary subject, e.g. `register:<ip>`. */
 export async function recordAttempt(db: Database, subject: string): Promise<void> {

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -42,7 +42,16 @@ const schema = z.object({
 	BACKUP_ENCRYPTION_KEY: z.preprocess(emptyStringAsUndefined, z.string().min(32).optional()),
 
 	/** Where database dumps are staged before they are streamed to the browser or to S3. */
-	BACKUP_TMP_DIR: z.string().default('./var/backups')
+	BACKUP_TMP_DIR: z.string().default('./var/backups'),
+
+	/**
+	 * When set, the logging mailer (see `mail/index.ts`) also appends every mail it "sends" to this
+	 * file as JSON lines. Only end-to-end tests set this — it lets a separate test process recover a
+	 * verification or password-reset link without a real mailbox. Combined with `BREVO_API_KEY` being
+	 * unset (the logging mailer only exists for that case), setting this alone in a real deployment
+	 * has no effect.
+	 */
+	MAIL_TEST_OUTBOX: z.preprocess(emptyStringAsUndefined, z.string().optional())
 });
 
 export type Config = z.infer<typeof schema>;

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -339,6 +339,27 @@ export const passwordResets = pgTable(
 	(table) => [index('password_resets_user_idx').on(table.userId)]
 );
 
+/**
+ * Account-activation tokens, mailed out on registration and again on request.
+ *
+ * Same shape as `password_resets` — only the hash of the token is stored — but with a 24-hour TTL
+ * rather than one hour, since nobody is expected to check their mail within minutes of signing up.
+ */
+export const emailVerifications = pgTable(
+	'email_verifications',
+	{
+		/** SHA-256 of the token that was mailed out. */
+		id: text('id').primaryKey(),
+		userId: uuid('user_id')
+			.notNull()
+			.references(() => users.id, { onDelete: 'cascade' }),
+		expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+		usedAt: timestamp('used_at', { withTimezone: true }),
+		createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow()
+	},
+	(table) => [index('email_verifications_user_idx').on(table.userId)]
+);
+
 /** Failed login attempts, kept just long enough to throttle credential stuffing. */
 export const loginAttempts = pgTable(
 	'login_attempts',

--- a/src/lib/server/mail/index.ts
+++ b/src/lib/server/mail/index.ts
@@ -6,6 +6,8 @@
  * without credentials, and it prints the reset link so a local password reset can be completed.
  */
 
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { config } from '../config.ts';
 import { logger } from '../logger.ts';
 
@@ -59,6 +61,18 @@ function loggingMailer(): Mailer {
 				{ to: mail.to, subject: mail.subject, body: mail.text },
 				'mail not sent: BREVO_API_KEY is not configured'
 			);
+
+			// End-to-end tests run as a separate process from the app server and cannot read this
+			// process's log stream, so — only when explicitly opted in — mirror the mail to a file they
+			// can read instead. See the `MAIL_TEST_OUTBOX` doc comment in `config.ts`.
+			const outbox = config().MAIL_TEST_OUTBOX;
+			if (outbox) {
+				await mkdir(dirname(outbox), { recursive: true });
+				await appendFile(
+					outbox,
+					JSON.stringify({ to: mail.to, subject: mail.subject, text: mail.text }) + '\n'
+				);
+			}
 		}
 	};
 }

--- a/src/lib/server/repositories/users.spec.ts
+++ b/src/lib/server/repositories/users.spec.ts
@@ -1,0 +1,102 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, describe, expect, it } from 'vitest';
+import { closeDb, getDb } from '../db/index.ts';
+import { emailVerifications, users } from '../db/schema.ts';
+import {
+	consumeEmailVerification,
+	createEmailVerification,
+	createUser,
+	markEmailVerified,
+	peekEmailVerification
+} from './users.ts';
+
+/**
+ * Account-activation tokens.
+ *
+ * Runs against a real database (see `closeDb`, kept around for exactly this) rather than mocking
+ * drizzle's query builder, since the behaviour that matters — single use, expiry, the token itself
+ * never being stored — lives in the SQL `where` clause, not in application code a mock would exercise
+ * meaningfully.
+ */
+describe('email verification tokens', () => {
+	const db = getDb();
+	const createdUserIds: string[] = [];
+
+	async function makeUser(): Promise<string> {
+		const email = `verify-spec-${randomUUID()}@example.com`;
+		const result = await createUser(db, { email, password: 'a-fairly-good-password' });
+		if (!result.ok) throw new Error('failed to create test user');
+		createdUserIds.push(result.user.id);
+		return result.user.id;
+	}
+
+	afterAll(async () => {
+		for (const id of createdUserIds) {
+			await db.delete(users).where(eq(users.id, id));
+		}
+		await closeDb();
+	});
+
+	it('round-trips: a freshly issued token is valid, consuming it returns the owning user', async () => {
+		const userId = await makeUser();
+		const token = await createEmailVerification(db, userId);
+
+		await expect(peekEmailVerification(db, token)).resolves.toBe(true);
+
+		const result = await consumeEmailVerification(db, token);
+		expect(result).toEqual({ userId });
+	});
+
+	it('never stores the raw token, only its hash', async () => {
+		const userId = await makeUser();
+		const token = await createEmailVerification(db, userId);
+		const expectedId = createHash('sha256').update(token).digest('hex');
+
+		const [row] = await db
+			.select()
+			.from(emailVerifications)
+			.where(eq(emailVerifications.userId, userId));
+
+		expect(row?.id).toBe(expectedId);
+		expect(row?.id).not.toBe(token);
+	});
+
+	it('is single-use: a second consume of the same token fails', async () => {
+		const userId = await makeUser();
+		const token = await createEmailVerification(db, userId);
+
+		await expect(consumeEmailVerification(db, token)).resolves.toEqual({ userId });
+		await expect(consumeEmailVerification(db, token)).resolves.toBeNull();
+		await expect(peekEmailVerification(db, token)).resolves.toBe(false);
+	});
+
+	it('rejects an unknown token', async () => {
+		await expect(consumeEmailVerification(db, 'not-a-real-token')).resolves.toBeNull();
+		await expect(peekEmailVerification(db, 'not-a-real-token')).resolves.toBe(false);
+	});
+
+	it('rejects an expired token', async () => {
+		const userId = await makeUser();
+		const token = 'expired-test-token';
+
+		await db.insert(emailVerifications).values({
+			id: createHash('sha256').update(token).digest('hex'),
+			userId,
+			// Already in the past, unlike the 24h TTL `createEmailVerification` issues.
+			expiresAt: new Date(Date.now() - 1000)
+		});
+
+		await expect(peekEmailVerification(db, token)).resolves.toBe(false);
+		await expect(consumeEmailVerification(db, token)).resolves.toBeNull();
+	});
+
+	it('marks the account as verified', async () => {
+		const userId = await makeUser();
+
+		await markEmailVerified(db, userId);
+
+		const [row] = await db.select().from(users).where(eq(users.id, userId));
+		expect(row?.emailVerifiedAt).toBeInstanceOf(Date);
+	});
+});

--- a/src/lib/server/repositories/users.ts
+++ b/src/lib/server/repositories/users.ts
@@ -6,7 +6,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { and, eq, gt, isNull, sql } from 'drizzle-orm';
 import { config } from '../config.ts';
 import type { Database } from '../db/client.ts';
-import { passwordResets, users, type User } from '../db/schema.ts';
+import { emailVerifications, passwordResets, users, type User } from '../db/schema.ts';
 import { hashPassword } from '../auth/password.ts';
 import { normalizeFontScale } from '../reader-preferences.ts';
 
@@ -167,6 +167,80 @@ export async function consumePasswordReset(
 	return row ?? null;
 }
 
+const EMAIL_VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Issues an account-activation token.
+ *
+ * Same idea as `createPasswordReset`: only the hash is stored, so the mailed link is the only copy.
+ * The TTL is generous compared to a password reset, since nobody is expected to check their mail
+ * within minutes of registering.
+ */
+export async function createEmailVerification(db: Database, userId: string): Promise<string> {
+	const token = randomBytes(32).toString('base64url');
+
+	await db.insert(emailVerifications).values({
+		id: createHash('sha256').update(token).digest('hex'),
+		userId,
+		expiresAt: new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_MS)
+	});
+
+	return token;
+}
+
+/**
+ * True when a token exists, is unused and unexpired. Read-only — used only to decide what the
+ * confirmation page shows before the person has clicked the button, so it must not burn the token
+ * itself (mail clients and link scanners prefetch links).
+ */
+export async function peekEmailVerification(db: Database, token: string): Promise<boolean> {
+	const id = createHash('sha256').update(token).digest('hex');
+
+	const [row] = await db
+		.select({ id: emailVerifications.id })
+		.from(emailVerifications)
+		.where(
+			and(
+				eq(emailVerifications.id, id),
+				isNull(emailVerifications.usedAt),
+				gt(emailVerifications.expiresAt, new Date())
+			)
+		)
+		.limit(1);
+
+	return row !== undefined;
+}
+
+/** Consumes an activation token, returning the user it belongs to. Single use. */
+export async function consumeEmailVerification(
+	db: Database,
+	token: string
+): Promise<{ userId: string } | null> {
+	const id = createHash('sha256').update(token).digest('hex');
+
+	const [row] = await db
+		.update(emailVerifications)
+		.set({ usedAt: new Date() })
+		.where(
+			and(
+				eq(emailVerifications.id, id),
+				isNull(emailVerifications.usedAt),
+				gt(emailVerifications.expiresAt, new Date())
+			)
+		)
+		.returning({ userId: emailVerifications.userId });
+
+	return row ?? null;
+}
+
+/** Marks an account's email address as confirmed, activating it. */
+export async function markEmailVerified(db: Database, userId: string): Promise<void> {
+	await db
+		.update(users)
+		.set({ emailVerifiedAt: new Date(), updatedAt: new Date() })
+		.where(eq(users.id, userId));
+}
+
 /** Admin listing, with a count of each account's verse lists. */
 export async function listUsers(db: Database): Promise<
 	{
@@ -177,6 +251,7 @@ export async function listUsers(db: Database): Promise<
 		createdAt: Date;
 		lastLoginAt: Date | null;
 		disabledAt: Date | null;
+		emailVerifiedAt: Date | null;
 		listCount: number;
 	}[]
 > {
@@ -188,10 +263,11 @@ export async function listUsers(db: Database): Promise<
 		created_at: string;
 		last_login_at: string | null;
 		disabled_at: string | null;
+		email_verified_at: string | null;
 		list_count: number;
 	}>(sql`
 		select u.id, u.email, u.display_name, u.role, u.created_at, u.last_login_at, u.disabled_at,
-		       count(l.id)::int as list_count
+		       u.email_verified_at, count(l.id)::int as list_count
 		from users u
 		left join verse_lists l on l.user_id = u.id
 		group by u.id
@@ -206,6 +282,7 @@ export async function listUsers(db: Database): Promise<
 		createdAt: new Date(row.created_at),
 		lastLoginAt: row.last_login_at ? new Date(row.last_login_at) : null,
 		disabledAt: row.disabled_at ? new Date(row.disabled_at) : null,
+		emailVerifiedAt: row.email_verified_at ? new Date(row.email_verified_at) : null,
 		listCount: Number(row.list_count)
 	}));
 }

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -2,6 +2,7 @@ import { fail } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
 import { destroyAllSessions } from '$lib/server/auth/session';
 import {
+	createEmailVerification,
 	createPasswordReset,
 	listUsers,
 	setUserDisabled,
@@ -55,6 +56,21 @@ export const actions = {
 		return {
 			resetLink: new URL(`/password-reset/${token}`, config().ORIGIN).toString(),
 			resetFor: userId
+		};
+	},
+
+	/**
+	 * Issues a fresh account-activation link, for when someone never received (or lost) the original
+	 * one. Shown to the admin rather than emailed, same reasoning as `reset` above.
+	 */
+	verify: async ({ request }) => {
+		const form = await request.formData();
+		const userId = String(form.get('userId') ?? '');
+		const token = await createEmailVerification(getDb(), userId);
+
+		return {
+			verifyLink: new URL(`/register/verify/${token}`, config().ORIGIN).toString(),
+			verifyFor: userId
 		};
 	}
 };

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -28,6 +28,20 @@
 	</div>
 {/if}
 
+{#if form?.verifyLink}
+	<div
+		class="mb-4 rounded-md border border-stone-200 bg-stone-50 p-3 text-sm dark:border-stone-800 dark:bg-stone-900"
+	>
+		<p class="mb-1">Einmal-Link zur Aktivierung (24 Stunden gültig):</p>
+		<input
+			readonly
+			value={form.verifyLink}
+			onclick={(event) => event.currentTarget.select()}
+			class="w-full rounded border border-stone-300 px-2 py-1 font-mono text-xs dark:border-stone-700 dark:bg-stone-950"
+		/>
+	</div>
+{/if}
+
 <div class="overflow-x-auto">
 	<table class="w-full text-sm">
 		<thead class="text-left text-xs text-stone-500 dark:text-stone-400">
@@ -44,7 +58,12 @@
 		<tbody class="divide-y divide-stone-200 dark:divide-stone-800">
 			{#each data.users as user (user.id)}
 				<tr class:opacity-50={user.disabledAt}>
-					<td class="py-2 pr-3">{user.email}</td>
+					<td class="py-2 pr-3">
+						{user.email}
+						{#if !user.emailVerifiedAt}
+							<span class="ml-1 text-xs text-amber-700 dark:text-amber-400">(nicht aktiviert)</span>
+						{/if}
+					</td>
 					<td class="py-2 pr-3">{user.displayName ?? '—'}</td>
 					<td class="py-2 pr-3">
 						<form method="POST" action="?/role" class="flex items-center gap-1">
@@ -72,6 +91,14 @@
 									Passwort-Link
 								</button>
 							</form>
+							{#if !user.emailVerifiedAt}
+								<form method="POST" action="?/verify">
+									<input type="hidden" name="userId" value={user.id} />
+									<button type="submit" class="text-xs text-accent-600 hover:underline">
+										Aktivierungslink
+									</button>
+								</form>
+							{/if}
 							<form method="POST" action="?/disable">
 								<input type="hidden" name="userId" value={user.id} />
 								<input type="hidden" name="disabled" value={user.disabledAt ? 'false' : 'true'} />

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,14 +1,22 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
+import { config } from '$lib/server/config';
 import { dummyHash, verifyPassword } from '$lib/server/auth/password';
 import { createSession } from '$lib/server/auth/session';
 import {
 	clearFailedLogins,
+	countRecent,
 	isLoginThrottled,
 	pruneLoginAttempts,
 	recordFailedLogin
 } from '$lib/server/auth/rate-limit';
-import { findUserByEmail, recordLogin } from '$lib/server/repositories/users';
+import { mailer } from '$lib/server/mail';
+import { logger } from '$lib/server/logger';
+import {
+	createEmailVerification,
+	findUserByEmail,
+	recordLogin
+} from '$lib/server/repositories/users';
 import { updateReaderColumns } from '$lib/server/repositories/users';
 import { listBibles } from '$lib/server/repositories/resources';
 import { readColumns } from '$lib/server/columns';
@@ -47,6 +55,13 @@ export const actions = {
 			return fail(400, { email, error: 'invalid' as const });
 		}
 
+		if (!user.emailVerifiedAt) {
+			// The password was correct, so this can say exactly what is wrong without helping anyone
+			// probe for which addresses are registered — that question is already answered by getting
+			// this far instead of "invalid".
+			return fail(400, { email, error: 'unverified' as const });
+		}
+
 		await clearFailedLogins(db, email, address);
 		await pruneLoginAttempts(db);
 		if (user.readerColumns.length === 0) {
@@ -57,5 +72,52 @@ export const actions = {
 
 		// Only same-site paths, so a crafted link cannot bounce someone off the site after signing in.
 		redirect(303, redirectTo.startsWith('/') ? redirectTo : '/account');
+	},
+
+	/**
+	 * Re-sends the account-activation mail, offered once login fails with `unverified`.
+	 *
+	 * Same shape as the password-reset request: the response never says whether the address exists
+	 * or is already verified, and IP throttling stands in for a per-account limit since there is no
+	 * failed-login history to key on before the account is even active.
+	 */
+	resend: async ({ request, getClientAddress }) => {
+		const form = await request.formData();
+		const email = String(form.get('email') ?? '').trim();
+		if (!email.includes('@')) return fail(400, { error: 'email' as const });
+
+		const db = getDb();
+		const address = getClientAddress();
+
+		if ((await countRecent(db, `ip:${address}`)) >= 10) {
+			return fail(429, { error: 'throttled' as const });
+		}
+		await recordFailedLogin(db, email, address);
+
+		const user = await findUserByEmail(db, email);
+
+		if (user && !user.disabledAt && !user.emailVerifiedAt) {
+			const token = await createEmailVerification(db, user.id);
+			const link = new URL(`/register/verify/${token}`, config().ORIGIN).toString();
+
+			try {
+				await mailer().send({
+					to: user.email,
+					subject: 'strongs.de: Bitte bestätige deine E-Mail-Adresse',
+					text: [
+						'Du hast eine neue Aktivierungsmail für dein Konto auf strongs.de angefordert.',
+						'',
+						`Bitte bestätige deine E-Mail-Adresse über diesen Link: ${link}`,
+						'',
+						'Der Link ist 24 Stunden gültig und kann nur einmal verwendet werden.',
+						'Wenn du das nicht warst, kannst du diese E-Mail ignorieren.'
+					].join('\n')
+				});
+			} catch (error) {
+				logger.error({ err: error }, 'sending the verification mail failed');
+			}
+		}
+
+		return { resent: true };
 	}
 };

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -27,7 +27,10 @@ export async function load({ locals, url }) {
 }
 
 export const actions = {
-	default: async ({ request, cookies, getClientAddress }) => {
+	// Named rather than default: SvelteKit forbids mixing a default action with named ones in the
+	// same route, and `resend` below needs to be named. The form in +page.svelte points at this
+	// explicitly via `action="?/login"`.
+	login: async ({ request, cookies, getClientAddress }) => {
 		const form = await request.formData();
 		const email = String(form.get('email') ?? '');
 		const password = String(form.get('password') ?? '');

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -5,18 +5,26 @@
 
 	let { data, form } = $props();
 
-	const message = $derived(
+	const errorMessage = $derived(
 		form?.error === 'throttled'
 			? t('auth.login.throttled')
-			: form?.error
-				? t('auth.login.failed')
-				: null
+			: form?.error === 'unverified'
+				? t('auth.login.unverified')
+				: form?.error
+					? t('auth.login.failed')
+					: null
 	);
+	const notice = $derived(!form?.error && form?.resent ? t('auth.register.resendSent') : null);
 </script>
 
 <svelte:head><title>{t('auth.login.title')} — strongs.de</title></svelte:head>
 
-<AuthForm title={t('auth.login.title')} error={message} submitLabel={t('auth.login.submit')}>
+<AuthForm
+	title={t('auth.login.title')}
+	error={errorMessage}
+	{notice}
+	submitLabel={t('auth.login.submit')}
+>
 	<input type="hidden" name="redirectTo" value={data.redirectTo} />
 	<TextField
 		name="email"
@@ -33,6 +41,20 @@
 		autocomplete="current-password"
 		required
 	/>
+
+	{#if form?.error === 'unverified'}
+		<!-- formnovalidate: the resend action only needs the email above, not the (possibly empty
+			 after the reload) password field, which `required` would otherwise block this on. -->
+		<button
+			type="submit"
+			formaction="?/resend"
+			formnovalidate
+			class="w-full rounded-md border border-stone-300 px-3 py-2 text-sm font-medium
+			       hover:bg-stone-50 dark:border-stone-700 dark:hover:bg-stone-800"
+		>
+			{t('auth.register.resendVerification')}
+		</button>
+	{/if}
 
 	{#snippet footer()}
 		<p>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -24,6 +24,7 @@
 	error={errorMessage}
 	{notice}
 	submitLabel={t('auth.login.submit')}
+	action="?/login"
 >
 	<input type="hidden" name="redirectTo" value={data.redirectTo} />
 	<TextField

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -1,8 +1,11 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
+import { config } from '$lib/server/config';
 import { checkPasswordStrength, MIN_PASSWORD_LENGTH } from '$lib/server/auth/password';
-import { createSession } from '$lib/server/auth/session';
-import { createUser } from '$lib/server/repositories/users';
+import { countRecent, recordAttempt } from '$lib/server/auth/rate-limit';
+import { mailer } from '$lib/server/mail';
+import { logger } from '$lib/server/logger';
+import { createEmailVerification, createUser } from '$lib/server/repositories/users';
 import { updateReaderColumns } from '$lib/server/repositories/users';
 import { listBibles } from '$lib/server/repositories/resources';
 import { readColumns } from '$lib/server/columns';
@@ -13,31 +16,65 @@ export async function load({ locals }) {
 }
 
 export const actions = {
-	default: async ({ request, cookies }) => {
+	default: async ({ request, cookies, getClientAddress }) => {
 		const form = await request.formData();
 		const email = String(form.get('email') ?? '').trim();
 		const password = String(form.get('password') ?? '');
 		const repeat = String(form.get('passwordRepeat') ?? '');
 		const displayName = String(form.get('displayName') ?? '').trim();
+		// Honeypot: invisible and unreachable by keyboard for a person (see the field in
+		// +page.svelte), but a script that blindly fills every field in the form trips it.
+		const honeypot = String(form.get('company') ?? '').trim();
 
 		const values = { email, displayName };
+
+		if (honeypot) {
+			// Silently pretend it worked: a bot that is refused just tries again, one that is told it
+			// succeeded has no signal that it was caught. Nothing is created and no mail is sent.
+			redirect(303, '/register/check-email');
+		}
 
 		if (!email.includes('@')) return fail(400, { ...values, error: 'email' as const });
 		if (password !== repeat) return fail(400, { ...values, error: 'mismatch' as const });
 		if (checkPasswordStrength(password)) return fail(400, { ...values, error: 'weak' as const });
 
 		const db = getDb();
+		const address = getClientAddress();
+
+		// Per-address only, unlike login: there is no account yet to also key on.
+		if ((await countRecent(db, `register:${address}`)) >= 10) {
+			return fail(429, { ...values, error: 'throttled' as const });
+		}
+		await recordAttempt(db, `register:${address}`);
+
 		const result = await createUser(db, { email, password, displayName });
 
 		if (!result.ok) return fail(400, { ...values, error: 'taken' as const });
 
 		await updateReaderColumns(db, result.user.id, readColumns(cookies, await listBibles(db)));
-		await createSession(
-			db,
-			cookies,
-			result.user.id,
-			request.headers.get('user-agent') ?? undefined
-		);
-		redirect(303, '/account');
+
+		const token = await createEmailVerification(db, result.user.id);
+		const link = new URL(`/register/verify/${token}`, config().ORIGIN).toString();
+
+		try {
+			await mailer().send({
+				to: result.user.email,
+				subject: 'strongs.de: Bitte bestätige deine E-Mail-Adresse',
+				text: [
+					'Willkommen bei strongs.de!',
+					'',
+					`Bitte bestätige deine E-Mail-Adresse über diesen Link: ${link}`,
+					'',
+					'Der Link ist 24 Stunden gültig und kann nur einmal verwendet werden.',
+					'Wenn du dieses Konto nicht angelegt hast, kannst du diese E-Mail ignorieren.'
+				].join('\n')
+			});
+		} catch (error) {
+			// The account still exists; a mail failure must not block registration, only be logged.
+			logger.error({ err: error }, 'sending the verification mail failed');
+		}
+
+		// No session yet — that only happens once the link above is confirmed.
+		redirect(303, '/register/check-email');
 	}
 };

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
 import { config } from '$lib/server/config';
 import { checkPasswordStrength, MIN_PASSWORD_LENGTH } from '$lib/server/auth/password';
-import { countRecent, recordAttempt } from '$lib/server/auth/rate-limit';
+import { countRecent, LIMITS, recordAttempt } from '$lib/server/auth/rate-limit';
 import { mailer } from '$lib/server/mail';
 import { logger } from '$lib/server/logger';
 import { createEmailVerification, createUser } from '$lib/server/repositories/users';
@@ -42,7 +42,7 @@ export const actions = {
 		const address = getClientAddress();
 
 		// Per-address only, unlike login: there is no account yet to also key on.
-		if ((await countRecent(db, `register:${address}`)) >= 10) {
+		if ((await countRecent(db, `register:${address}`)) >= LIMITS.MAX_REGISTRATIONS_PER_ADDRESS) {
 			return fail(429, { ...values, error: 'throttled' as const });
 		}
 		await recordAttempt(db, `register:${address}`);

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -14,7 +14,9 @@
 					? t('auth.register.passwordTooShort', { min: data.minPasswordLength })
 					: form?.error === 'email'
 						? t('auth.email')
-						: null
+						: form?.error === 'throttled'
+							? t('auth.register.throttled')
+							: null
 	);
 </script>
 
@@ -51,6 +53,23 @@
 		autocomplete="new-password"
 		required
 	/>
+
+	<!--
+		Honeypot: a native input, not TextField, since a person must never be able to focus, read or
+		fill it. A script that fills every field in the form (rather than the ones a person sees) trips
+		it; the server then answers as if registration succeeded without creating an account.
+	-->
+	<div class="absolute -left-[9999px] h-0 w-0 overflow-hidden" aria-hidden="true">
+		<label for="company">Firma</label>
+		<input
+			type="text"
+			id="company"
+			name="company"
+			tabindex="-1"
+			autocomplete="off"
+			style="opacity: 0; pointer-events: none;"
+		/>
+	</div>
 
 	{#snippet footer()}
 		<p>

--- a/src/routes/register/check-email/+page.server.ts
+++ b/src/routes/register/check-email/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load({ locals }) {
+	if (locals.user) redirect(303, '/account');
+}

--- a/src/routes/register/check-email/+page.svelte
+++ b/src/routes/register/check-email/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { t } from '$lib/i18n';
+</script>
+
+<svelte:head><title>{t('auth.register.checkEmailTitle')} — strongs.de</title></svelte:head>
+
+<main
+	class="mx-auto my-8 w-[calc(100%-2rem)] max-w-sm rounded-xl border border-stone-200 bg-white px-6 py-7
+			 text-center shadow-[0_12px_40px_rgb(28_25_23/0.08)] dark:border-stone-800 dark:bg-stone-900/70"
+>
+	<div
+		class="mb-6 flex items-center justify-center gap-3 border-b border-stone-100 pb-4 dark:border-stone-800"
+	>
+		<img src="/icon.png" alt="" class="size-9 rounded-sm" />
+		<h1 class="font-serif text-2xl font-semibold text-stone-800 dark:text-stone-100">
+			{t('auth.register.checkEmailTitle')}
+		</h1>
+	</div>
+
+	<p class="text-sm text-stone-600 dark:text-stone-300">{t('auth.register.checkEmailBody')}</p>
+
+	<p class="mt-5 text-sm">
+		<a class="text-accent-600 hover:underline dark:text-accent-400" href="/login">
+			{t('auth.login.title')}
+		</a>
+	</p>
+</main>

--- a/src/routes/register/verify/[token]/+page.server.ts
+++ b/src/routes/register/verify/[token]/+page.server.ts
@@ -1,0 +1,35 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db';
+import { createSession } from '$lib/server/auth/session';
+import {
+	consumeEmailVerification,
+	markEmailVerified,
+	peekEmailVerification,
+	updateReaderColumns
+} from '$lib/server/repositories/users';
+import { listBibles } from '$lib/server/repositories/resources';
+import { readColumns } from '$lib/server/columns';
+
+export async function load({ params, locals }) {
+	if (locals.user) redirect(303, '/account');
+
+	// Not consumed here: doing so would burn a single-use token, and mail clients and link scanners
+	// follow links on their own before a person ever clicks anything (see password-reset's `load` for
+	// the same reasoning). This only decides what the confirmation button below says.
+	const valid = await peekEmailVerification(getDb(), params.token);
+	return { valid };
+}
+
+export const actions = {
+	default: async ({ params, cookies, request }) => {
+		const db = getDb();
+		const result = await consumeEmailVerification(db, params.token);
+		if (!result) return fail(400, { error: 'token' as const });
+
+		await markEmailVerified(db, result.userId);
+		await updateReaderColumns(db, result.userId, readColumns(cookies, await listBibles(db)));
+		await createSession(db, cookies, result.userId, request.headers.get('user-agent') ?? undefined);
+
+		redirect(303, '/account');
+	}
+};

--- a/src/routes/register/verify/[token]/+page.svelte
+++ b/src/routes/register/verify/[token]/+page.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { t } from '$lib/i18n';
+
+	let { data, form } = $props();
+
+	const invalid = $derived(form?.error === 'token' || !data.valid);
+</script>
+
+<svelte:head><title>{t('auth.register.verifyTitle')} — strongs.de</title></svelte:head>
+
+<main
+	class="mx-auto my-8 w-[calc(100%-2rem)] max-w-sm rounded-xl border border-stone-200 bg-white px-6 py-7
+			 shadow-[0_12px_40px_rgb(28_25_23/0.08)] dark:border-stone-800 dark:bg-stone-900/70"
+>
+	<div class="mb-6 flex items-center gap-3 border-b border-stone-100 pb-4 dark:border-stone-800">
+		<img src="/icon.png" alt="" class="size-9 rounded-sm" />
+		<h1 class="font-serif text-2xl font-semibold text-stone-800 dark:text-stone-100">
+			{t('auth.register.verifyTitle')}
+		</h1>
+	</div>
+
+	{#if invalid}
+		<p
+			class="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800
+			       dark:border-red-900 dark:bg-red-950 dark:text-red-200"
+			role="alert"
+		>
+			{t('auth.register.verifyInvalid')}
+		</p>
+		<p class="text-sm">
+			<a class="text-accent-600 hover:underline dark:text-accent-400" href="/register">
+				{t('auth.register.title')}
+			</a>
+		</p>
+	{:else}
+		<p class="text-sm text-stone-600 dark:text-stone-300">{t('auth.register.verifyBody')}</p>
+		<form method="POST" class="mt-4">
+			<button
+				type="submit"
+				class="w-full rounded-md bg-accent-600 px-3 py-2 text-sm font-medium text-white
+				       hover:bg-accent-700 focus-visible:outline-2"
+			>
+				{t('auth.register.verifySubmit')}
+			</button>
+		</form>
+	{/if}
+</main>


### PR DESCRIPTION
## Summary

Todo.md #3: "Sicherheit: Aktivierung des Kontos durch Email-Versand nötig. Honeypot einbauen zur Absicherung der Registrierung."

- Neue `email_verifications`-Tabelle (Migration `0012`), Token-Hashing/Single-Use/24h-TTL analog zum bestehenden Passwort-Reset-Flow.
- Registrierung erstellt keine Session mehr sofort — stattdessen wird eine Aktivierungsmail versendet und auf `/register/check-email` weitergeleitet. Bestätigung über `/register/verify/[token]` (GET zeigt nur an, POST konsumiert den Token und loggt ein — schützt gegen Mail-Scanner, die Links prefetchen).
- Login gated auf `emailVerifiedAt`, mit Fehlermeldung + Möglichkeit, die Aktivierungsmail erneut anzufordern.
- Admin kann für einen Nutzer manuell einen neuen Aktivierungslink ausstellen (`admin/users`).
- Verstecktes Honeypot-Feld in der Registrierung — bei Befüllung wird die Registrierung stillschweigend als "Erfolg" beantwortet, ohne dass ein Account angelegt wird.
- Eigenes Rate-Limit für Registrierungsversuche (separat vom Login/Reset-Limit).
- Der bereits geseedete Admin-Account wird direkt bei der Erstellung als verifiziert markiert (kein Registrierungs-Flow für ihn).

**Zwei Bugs während der Implementierung gefunden und gefixt** (erst durch den vollständigen e2e-Lauf aufgefallen):
1. Eine zusätzliche `resend`-Action neben der `default`-Login-Action verstößt gegen SvelteKits Regel "keine `default`-Action neben benannten Actions" — jeder reguläre Login wäre mit 500 fehlgeschlagen. Login-Action in `login` umbenannt.
2. Das ursprüngliche Rate-Limit (10/IP, wie beim Passwort-Reset) war für die e2e-Suite (~20 Registrierungen von einer Adresse) zu eng — auf einen eigenen, großzügigeren Wert (50) angehoben, da Registrierung legitim mehr Traffic von gemeinsam genutzten IPs sieht als fehlgeschlagene Logins/Resets.

## Test plan

- [x] `pnpm check` — 0 Fehler
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 328/328
- [x] `pnpm test:e2e` — 71/71 (inkl. neuer `e2e/register.e2e.ts`: Aktivierung, Login-Gate, Honeypot)
- [x] Bestehende `account.e2e.ts`/`admin-backup.e2e.ts`/`api.e2e.ts`-Helper (`register()`) an den neuen Zwei-Schritt-Flow angepasst

🤖 Generated with [Claude Code](https://claude.com/claude-code)