### PR TITLE
Add global menu, move Impressum/Datenschutz out of the top bar

### DIFF
--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -34,15 +34,21 @@ test('the root redirects into the reader', async ({ page }) => {
 	await expect(page).toHaveURL(/\/Joh1$/);
 });
 
-test('Impressum and Datenschutz are reachable from the site header', async ({ page }) => {
+test('Impressum and Datenschutz are reachable only from the global menu', async ({ page }) => {
 	await page.goto('/Joh3');
 
-	await page.getByRole('link', { name: 'Impressum' }).click();
+	// No longer direct top-bar links — only reachable through the global menu.
+	await expect(page.getByRole('banner').getByRole('link', { name: 'Impressum' })).toHaveCount(0);
+	await expect(page.getByRole('banner').getByRole('link', { name: 'Datenschutz' })).toHaveCount(0);
+
+	await page.getByRole('button', { name: 'Menü öffnen' }).click();
+	await page.getByRole('menuitem', { name: 'Impressum' }).click();
 	await expect(page).toHaveURL(/\/impressum$/);
 	await expect(page.getByRole('heading', { level: 1 })).toContainText('Impressum');
 
 	await page.goto('/Joh3');
-	await page.getByRole('link', { name: 'Datenschutz' }).click();
+	await page.getByRole('button', { name: 'Menü öffnen' }).click();
+	await page.getByRole('menuitem', { name: 'Datenschutz' }).click();
 	await expect(page).toHaveURL(/\/datenschutz$/);
 	await expect(page.getByRole('heading', { level: 1 })).toContainText('Datenschutzerklärung');
 });

--- a/src/lib/components/GlobalMenu.svelte
+++ b/src/lib/components/GlobalMenu.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { t } from '$lib/i18n';
+	import Menu from './Menu.svelte';
+
+	/**
+	 * The site's global menu — reachable from a hamburger button that is always visible, regardless
+	 * of viewport width.
+	 *
+	 * It holds two kinds of content: links that `SiteHeader` used to show only from `sm:` upward
+	 * (lists/account/admin, for a signed-in visitor) so nothing is lost on narrow viewports, plus
+	 * Impressum/Datenschutz, which live here exclusively now — they are no longer in the top bar at
+	 * all, on any viewport.
+	 */
+	let {
+		user = null
+	}: {
+		user?: { displayName: string | null; email: string; role: string } | null;
+	} = $props();
+
+	let menu: Menu | undefined = $state();
+
+	/**
+	 * `menu.isOpen()` reads a `$state` that lives inside `Menu`, but Svelte's reactivity tracks the
+	 * signal itself, not which component reads it — so this stays in sync with the popover without
+	 * `Menu` needing to expose an event for it.
+	 */
+	let expanded = $derived(menu?.isOpen() ?? false);
+</script>
+
+<button
+	type="button"
+	aria-label={t('nav.menuOpen')}
+	aria-haspopup="menu"
+	aria-expanded={expanded}
+	class="rounded-md px-2 py-1.5 text-stone-500 hover:bg-stone-100 hover:text-stone-900
+	       dark:hover:bg-stone-800 dark:hover:text-stone-100"
+	onclick={(event) => menu?.openAt(event.currentTarget)}
+>
+	<svg viewBox="0 0 20 20" class="size-5" fill="currentColor" aria-hidden="true">
+		<path
+			fill-rule="evenodd"
+			d="M2.5 5.5a.75.75 0 0 1 .75-.75h13.5a.75.75 0 0 1 0 1.5H3.25a.75.75 0 0 1-.75-.75Zm0 4.5a.75.75 0 0 1 .75-.75h13.5a.75.75 0 0 1 0 1.5H3.25A.75.75 0 0 1 2.5 10Zm0 4.5a.75.75 0 0 1 .75-.75h13.5a.75.75 0 0 1 0 1.5H3.25a.75.75 0 0 1-.75-.75Z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+</button>
+
+<Menu bind:this={menu} label={t('nav.menu')}>
+	{#if user}
+		<a
+			role="menuitem"
+			href="/lists"
+			data-active={page.url.pathname.startsWith('/lists') ? 'true' : undefined}
+		>
+			{t('nav.lists')}
+		</a>
+		<a role="menuitem" href="/account">
+			{user.displayName ?? user.email}
+		</a>
+		{#if user.role === 'admin'}
+			<a role="menuitem" href="/admin">{t('nav.admin')}</a>
+		{/if}
+		<hr />
+	{/if}
+	<a role="menuitem" href="/impressum">{t('nav.impressum')}</a>
+	<a role="menuitem" href="/datenschutz">{t('nav.datenschutz')}</a>
+</Menu>

--- a/src/lib/components/SiteHeader.svelte
+++ b/src/lib/components/SiteHeader.svelte
@@ -4,6 +4,7 @@
 	import { parseReference } from '$lib/bible/reference';
 	import { jumpToVerse } from '$lib/reader-location.svelte';
 	import { t } from '$lib/i18n';
+	import GlobalMenu from './GlobalMenu.svelte';
 	import ReaderViewMenu from './ReaderViewMenu.svelte';
 	import ThemeToggle from './ThemeToggle.svelte';
 
@@ -215,35 +216,7 @@
 				</svg>
 			</a>
 
-			{#if user}
-				<a
-					href="/lists"
-					class="hidden rounded-md px-2.5 py-2 text-sm font-medium text-stone-600 hover:bg-accent-50
-					       hover:text-accent-800 data-[active=true]:text-accent-700 sm:block dark:text-stone-300
-					       dark:hover:bg-accent-900/30 dark:hover:text-accent-300"
-					data-active={page.url.pathname.startsWith('/lists') ? 'true' : undefined}
-				>
-					{t('nav.lists')}
-				</a>
-				<a
-					href="/account"
-					class="hidden rounded-md px-2.5 py-2 text-sm font-medium text-stone-600 hover:bg-accent-50
-					       hover:text-accent-800 sm:block dark:text-stone-300 dark:hover:bg-accent-900/30
-					       dark:hover:text-accent-300"
-				>
-					{user.displayName ?? user.email}
-				</a>
-				{#if user.role === 'admin'}
-					<a
-						href="/admin"
-						class="hidden rounded-md px-2.5 py-2 text-sm font-medium text-stone-600 hover:bg-accent-50
-						       hover:text-accent-800 sm:block dark:text-stone-300 dark:hover:bg-accent-900/30
-						       dark:hover:text-accent-300"
-					>
-						{t('nav.admin')}
-					</a>
-				{/if}
-			{:else}
+			{#if !user}
 				<a
 					href="/login"
 					class="rounded-md px-2 py-1.5 text-sm text-stone-600 hover:bg-stone-100
@@ -254,20 +227,7 @@
 				</a>
 			{/if}
 
-			<a
-				href="/impressum"
-				class="rounded-md px-1.5 py-1.5 text-xs text-stone-400 hover:text-stone-600
-				       dark:text-stone-500 dark:hover:text-stone-300"
-			>
-				{t('nav.impressum')}
-			</a>
-			<a
-				href="/datenschutz"
-				class="rounded-md px-1.5 py-1.5 text-xs text-stone-400 hover:text-stone-600
-				       dark:text-stone-500 dark:hover:text-stone-300"
-			>
-				{t('nav.datenschutz')}
-			</a>
+			<GlobalMenu {user} />
 		</nav>
 	</div>
 </header>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -39,6 +39,8 @@ export const de = {
 	'nav.theme.dark': 'Dunkles Design',
 	'nav.impressum': 'Impressum',
 	'nav.datenschutz': 'Datenschutz',
+	'nav.menu': 'Menü',
+	'nav.menuOpen': 'Menü öffnen',
 
 	// --- reader -------------------------------------------------------------
 	'reader.chooseTranslation': 'Übersetzung wählen',


### PR DESCRIPTION
## Summary

Todo.md #5: "Impressum und Datenschutz Links in das Menü verschieben. Ein neues globales Menü bauen mit allen Inhalten aus der Top Bar."

- Neue `GlobalMenu.svelte`: ein Hamburger-Button, der ein `Menu.svelte`-Popover öffnet (wiederverwendet die bestehende generische Popover-Komponente, keine neue Tastatursteuerung erfunden).
- Enthält alle Links, die bisher nur ab `sm:`-Breakpoint sichtbar waren (Listen, Account, Admin — auf Mobile bleibt dadurch nichts verloren), plus Impressum und Datenschutz.
- Impressum/Datenschutz-Links wurden aus der Top-Bar komplett entfernt (auf jedem Viewport, nicht nur mobil) — nur noch über das neue Menü erreichbar, wie gefordert.
- Bestehender e2e-Test umbenannt/umgeschrieben: prüft jetzt, dass die Links **nicht** mehr direkt in der Top-Bar (`role="banner"`) stehen, aber über das geöffnete Menü erreichbar sind.

## Test plan

- [x] `pnpm check` — 0 Fehler (16 vorbestehende Warnungen, unverändert)
- [x] `pnpm lint` — clean
- [x] `pnpm test:e2e` — 66/67 (1 vorbestehender Skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)