### PR TITLE
Add direct download and restore for existing local/S3 backups

### DIFF
--- a/e2e/admin-backup.e2e.ts
+++ b/e2e/admin-backup.e2e.ts
@@ -1,5 +1,5 @@
 import { open } from 'node:fs/promises';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -10,12 +10,50 @@ import { expect, test } from '@playwright/test';
  *
  * The destructive full restore round-trip is deliberately not included here: it drops and recreates
  * every table in the shared e2e database, which any other test running concurrently would trip over.
- * These tests cover the parts that do not require that: navigation/authorisation, the manual download
- * (which does need `pg_dump` on the host, hence the `hasPgDump` guard), S3 settings persistence
- * without leaking the secret, and the restore flow's server-side guards (wrong confirmation phrase,
- * invalid file) — submitted by calling `form.requestSubmit()` directly rather than clicking the
- * (client-disabled) submit button, since the check that actually matters is the server's.
+ * That applies just as much to the two direct-restore sources (an existing local copy, an S3 object) as
+ * it does to the upload path — none of the three are exercised end to end here. These tests cover the
+ * parts that do not require that: navigation/authorisation, the manual download (which does need
+ * `pg_dump` on the host, hence the `hasPgDump` guard), S3 settings persistence without leaking the
+ * secret, downloading an existing local copy directly, and every restore path's server-side guards
+ * (wrong confirmation phrase, invalid file) — submitted by calling `form.requestSubmit()` directly
+ * rather than clicking the (client-disabled) submit button, since the check that actually matters is
+ * the server's.
+ *
+ * Restoring directly from an S3 object is not covered at all: the admin UI only ever renders a
+ * restore-from-S3 button for an object returned by `?/listRemote`, which itself requires a reachable,
+ * writable bucket — not available in this environment or in CI. `s3.spec.ts` and `jobs.spec.ts` cover
+ * `getObjectStream`/`stageFromS3` against a mocked S3 client instead (see the summary in the PR/commit
+ * description for what that does and does not prove).
  */
+
+/** Matches `BACKUP_FILE_PATTERN` in `src/lib/server/backup/retention.ts`. */
+function fakeBackupName(offsetSeconds: number): string {
+	const at = new Date(Date.now() + offsetSeconds * 1000);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	const stamp =
+		`${at.getUTCFullYear()}${pad(at.getUTCMonth() + 1)}${pad(at.getUTCDate())}-` +
+		`${pad(at.getUTCHours())}${pad(at.getUTCMinutes())}${pad(at.getUTCSeconds())}`;
+	return `strongs-${stamp}.dump`;
+}
+
+/**
+ * `BACKUP_TMP_DIR`'s default (see `.env.example`), which the e2e `webServer` does not override —
+ * matches what `src/lib/server/config.ts` resolves to when the preview server and this test process
+ * share the same working directory and filesystem, as they do here.
+ */
+function localBackupsDir(): string {
+	return join(process.cwd(), 'var', 'backups');
+}
+
+function writeFakeLocalBackup(name: string, content: Buffer): string {
+	const dir = localBackupsDir();
+	mkdirSync(dir, { recursive: true });
+	const path = join(dir, name);
+	writeFileSync(path, content);
+	return path;
+}
+
+const VALID_DUMP_HEADER = Buffer.concat([Buffer.from('PGDMP', 'ascii'), Buffer.alloc(16)]);
 
 function uniqueEmail(): string {
 	return `e2e-backup-${Math.random().toString(36).slice(2, 10)}@example.com`;
@@ -151,4 +189,95 @@ test('restore refuses a file that is not a pg_dump', async ({ page }) => {
 
 	await page.getByLabel('Backup-Datei (.dump)').setInputFiles(path);
 	await expect(page.getByText(/keine gültige Backup-Datei/)).toBeVisible();
+});
+
+test('an existing local backup copy has its own download link and can be downloaded directly', async ({
+	page
+}) => {
+	// No `pg_dump` involved at all: this is a plain file already sitting where the scheduled backup
+	// would have left it, downloaded through the new per-row link — not the throwaway dump the
+	// "Sofort-Backup" button generates.
+	const name = fakeBackupName(0);
+	const path = writeFakeLocalBackup(name, VALID_DUMP_HEADER);
+
+	try {
+		await loginAsAdmin(page);
+		await page.goto('/admin/backup');
+
+		const row = page.locator('li').filter({ hasText: name });
+		await expect(row).toBeVisible();
+
+		const downloadPromise = page.waitForEvent('download');
+		await row.getByRole('link', { name: 'herunterladen' }).click();
+		const download = await downloadPromise;
+
+		expect(download.suggestedFilename()).toBe(name);
+		const downloadedPath = await download.path();
+		expect(downloadedPath).not.toBeNull();
+		expect(readFileSync(downloadedPath!).subarray(0, 5).toString('ascii')).toBe('PGDMP');
+
+		// Unlike `/admin/backup/download` (a fresh, throwaway dump), this is a durable copy — the
+		// route must not have deleted it after streaming.
+		expect(existsSync(path)).toBe(true);
+	} finally {
+		rmSync(path, { force: true });
+	}
+});
+
+test('restoreLocal refuses a wrong confirmation phrase', async ({ page }) => {
+	const name = fakeBackupName(1);
+	const path = writeFakeLocalBackup(name, VALID_DUMP_HEADER);
+
+	try {
+		await loginAsAdmin(page);
+		await page.goto('/admin/backup');
+
+		const row = page.locator('li').filter({ hasText: name });
+		await expect(row).toBeVisible();
+
+		await page.getByLabel(/Zur Bestätigung/).fill('falsch');
+		// Same reasoning as the upload form's equivalent test: the disabled button is convenience
+		// only, so the direct `requestSubmit()` is what proves the server enforces this independently.
+		await row
+			.locator('form[action="?/restoreLocal"]')
+			.evaluate((form) => (form as HTMLFormElement).requestSubmit());
+
+		await expect(page.getByText('Die Bestätigung stimmt nicht überein.')).toBeVisible();
+		await expect(page.getByText('Sicherung vor Wiederherstellung')).toHaveCount(0);
+		await expect(page.getByText('Wiederherstellung', { exact: true })).toHaveCount(0);
+	} finally {
+		rmSync(path, { force: true });
+	}
+});
+
+test('restoreLocal refuses a file that is not a valid pg_dump, without deleting it', async ({
+	page
+}) => {
+	// A file that matches the naming pattern but not the pg_dump magic bytes — e.g. corrupted on disk.
+	// The confirmation phrase is correct here, which is exactly the point: staging must reject the file
+	// on its content *before* a restore (and its mandatory pre-restore safety dump) is ever started.
+	const name = fakeBackupName(2);
+	const path = writeFakeLocalBackup(name, Buffer.from('not a dump'));
+
+	try {
+		await loginAsAdmin(page);
+		await page.goto('/admin/backup');
+
+		const row = page.locator('li').filter({ hasText: name });
+		await expect(row).toBeVisible();
+
+		await page.getByLabel(/Zur Bestätigung/).fill('WIEDERHERSTELLEN');
+		await row
+			.locator('form[action="?/restoreLocal"]')
+			.evaluate((form) => (form as HTMLFormElement).requestSubmit());
+
+		await expect(page.getByText('Das ist keine gültige Backup-Datei.')).toBeVisible();
+		await expect(page.getByText('Sicherung vor Wiederherstellung')).toHaveCount(0);
+		await expect(page.getByText('Wiederherstellung', { exact: true })).toHaveCount(0);
+		// The rejected file is a pre-existing local backup, not a throwaway upload — staging must not
+		// have deleted it merely for failing the format check.
+		expect(existsSync(path)).toBe(true);
+	} finally {
+		rmSync(path, { force: true });
+	}
 });

--- a/src/lib/server/backup/jobs.spec.ts
+++ b/src/lib/server/backup/jobs.spec.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { GetObjectCommand, type S3Client } from '@aws-sdk/client-s3';
+
+// `config()` (see `../config.ts`) caches its result on first call, so the override has to be in place
+// before `jobs.ts` is ever imported — same pattern as `crypto.spec.ts` uses for `BACKUP_ENCRYPTION_KEY`.
+const tmpDir = mkdtempSync(join(tmpdir(), 'strongs-backup-jobs-'));
+process.env.BACKUP_TMP_DIR = tmpDir;
+
+const { stageFromLocal, stageFromS3, stagedDumpPath } = await import('./jobs.ts');
+
+afterAll(async () => {
+	await rm(tmpDir, { recursive: true, force: true });
+});
+
+const DUMP_HEADER = Buffer.concat([Buffer.from('PGDMP', 'ascii'), Buffer.alloc(16, 1)]);
+
+function fakeS3Client(handler: (command: unknown) => unknown): S3Client {
+	return { send: vi.fn(async (command: unknown) => handler(command)) } as unknown as S3Client;
+}
+
+function writeLocalBackup(name: string, content: Buffer = DUMP_HEADER): string {
+	const path = join(tmpDir, name);
+	writeFileSync(path, content);
+	return path;
+}
+
+describe('stageFromLocal', () => {
+	it('rejects a name that does not match the backup file pattern', async () => {
+		await expect(stageFromLocal('../../etc/passwd')).rejects.toThrow('Ungültiger Dateiname.');
+		await expect(stageFromLocal('not-a-backup.dump')).rejects.toThrow('Ungültiger Dateiname.');
+	});
+
+	it('copies the file into a fresh staged path and leaves the original untouched', async () => {
+		const name = 'strongs-20260101-030000.dump';
+		writeLocalBackup(name);
+
+		const staged = await stageFromLocal(name);
+
+		expect(staged).not.toBe(join(tmpDir, name));
+		expect(staged.startsWith(tmpDir)).toBe(true);
+		expect(readFileSync(staged)).toEqual(DUMP_HEADER);
+		// The original local backup must still exist — staging must never consume it.
+		expect(readFileSync(join(tmpDir, name))).toEqual(DUMP_HEADER);
+	});
+
+	it('rejects a file that does not have a pg_dump custom-format header', async () => {
+		const name = 'strongs-20260102-030000.dump';
+		writeLocalBackup(name, Buffer.from('not a dump'));
+
+		await expect(stageFromLocal(name)).rejects.toThrow('Das ist keine gültige Backup-Datei.');
+		// The original stays put even though the staged copy failed validation.
+		expect(readFileSync(join(tmpDir, name)).toString()).toBe('not a dump');
+	});
+
+	it('reports a missing local backup as "not found" rather than a raw ENOENT', async () => {
+		await expect(stageFromLocal('strongs-20260103-030000.dump')).rejects.toThrow(
+			'Die lokale Sicherung wurde nicht gefunden.'
+		);
+	});
+});
+
+describe('stageFromS3', () => {
+	it('streams the object into a fresh staged path', async () => {
+		const client = fakeS3Client((command) => {
+			expect(command).toBeInstanceOf(GetObjectCommand);
+			return { Body: Readable.from(DUMP_HEADER), ContentLength: DUMP_HEADER.length };
+		});
+
+		const staged = await stageFromS3(client, { bucket: 'b', key: 'strongs/foo.dump' });
+
+		expect(staged.startsWith(tmpDir)).toBe(true);
+		expect(readFileSync(staged)).toEqual(DUMP_HEADER);
+	});
+
+	it('rejects and cleans up when the object is not a pg_dump custom-format file', async () => {
+		const client = fakeS3Client(() => ({
+			Body: Readable.from(Buffer.from('not a dump')),
+			ContentLength: 10
+		}));
+
+		await expect(stageFromS3(client, { bucket: 'b', key: 'strongs/foo.dump' })).rejects.toThrow(
+			'Das ist keine gültige Backup-Datei.'
+		);
+	});
+
+	it('propagates and cleans up on a stream error', async () => {
+		const client = fakeS3Client(() => ({
+			Body: new Readable({
+				read() {
+					this.destroy(new Error('connection reset'));
+				}
+			}),
+			ContentLength: 5
+		}));
+
+		await expect(stageFromS3(client, { bucket: 'b', key: 'strongs/foo.dump' })).rejects.toThrow(
+			'connection reset'
+		);
+	});
+});
+
+describe('stagedDumpPath', () => {
+	it('rejects an id that is not a strict UUID (path traversal guard)', () => {
+		expect(() => stagedDumpPath('../../etc/passwd')).toThrow('Ungültige Staging-ID.');
+	});
+});

--- a/src/lib/server/backup/jobs.ts
+++ b/src/lib/server/backup/jobs.ts
@@ -6,8 +6,12 @@
  * restarts is marked failed on the next boot (`failInterruptedBackupJobs`) rather than resumed.
  */
 
-import { mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdir, open, readdir, rm, stat, copyFile } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
 import { join } from 'node:path';
+import type { S3Client } from '@aws-sdk/client-s3';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import { config } from '../config.ts';
@@ -17,8 +21,8 @@ import { backupJobs, type BackupJob } from '../db/schema.ts';
 import { refreshStrongStatisticsBlocking } from '../db/statistics.ts';
 import { invalidateResourceCache } from '../repositories/resources.ts';
 import { pruneExpiredSessions } from '../auth/session.ts';
-import { dumpToFile, restoreFromFile } from './pg.ts';
-import { createS3Client, uploadFile, pruneRemote } from './s3.ts';
+import { dumpToFile, isCustomFormatDump, restoreFromFile } from './pg.ts';
+import { createS3Client, getObjectStream, uploadFile, pruneRemote } from './s3.ts';
 import {
 	backupFileName,
 	BACKUP_FILE_PATTERN,
@@ -200,6 +204,67 @@ export async function cleanStaleStagedFiles(): Promise<void> {
 			// Racing with an in-flight upload of the same file; leave it alone.
 		}
 	}
+}
+
+// --- staging an existing backup for direct restore ------------------------------
+
+async function assertCustomFormatDump(path: string): Promise<void> {
+	const handle = await open(path, 'r');
+	const head = Buffer.alloc(5);
+	try {
+		await handle.read(head, 0, 5, 0);
+	} finally {
+		await handle.close();
+	}
+	if (!isCustomFormatDump(head)) {
+		await rm(path, { force: true });
+		throw new Error('Das ist keine gültige Backup-Datei.');
+	}
+}
+
+/**
+ * Copies an existing local backup into a fresh staged path so it can be restored directly, without a
+ * detour through download + re-upload.
+ *
+ * Always a *copy*: `executeRestore`'s `finally` block unconditionally deletes the path it was given,
+ * so handing it the original file would delete that local backup as a side effect of restoring it.
+ */
+export async function stageFromLocal(name: string): Promise<string> {
+	if (!BACKUP_FILE_PATTERN.test(name)) throw new Error('Ungültiger Dateiname.');
+	const dir = config().BACKUP_TMP_DIR;
+	const source = join(dir, name);
+	await mkdir(dir, { recursive: true });
+	const dest = stagedDumpPath(randomUUID());
+	try {
+		await copyFile(source, dest);
+	} catch {
+		throw new Error('Die lokale Sicherung wurde nicht gefunden.');
+	}
+	await assertCustomFormatDump(dest);
+	return dest;
+}
+
+/**
+ * Streams an S3 object into a fresh staged path, exactly like `/admin/backup/upload` does for an
+ * HTTP upload, so it can be restored directly without downloading and re-uploading it by hand.
+ *
+ * Same copy-not-original rule as `stageFromLocal`: the staged path is always a new file.
+ */
+export async function stageFromS3(
+	client: S3Client,
+	options: { bucket: string; key: string }
+): Promise<string> {
+	await mkdir(config().BACKUP_TMP_DIR, { recursive: true });
+	const dest = stagedDumpPath(randomUUID());
+	try {
+		const { body } = await getObjectStream(client, options);
+		await pipeline(body, createWriteStream(dest));
+	} catch (error) {
+		await rm(dest, { force: true }).catch(() => {});
+		throw error;
+	}
+	await assertCustomFormatDump(dest);
+	return dest;
 }
 
 // --- manual download -----------------------------------------------------------

--- a/src/lib/server/backup/s3.spec.ts
+++ b/src/lib/server/backup/s3.spec.ts
@@ -1,12 +1,14 @@
+import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import {
 	DeleteObjectsCommand,
+	GetObjectCommand,
 	HeadBucketCommand,
 	ListObjectsV2Command,
 	PutObjectCommand,
 	type S3Client
 } from '@aws-sdk/client-s3';
-import { deleteKeys, listBackups, pruneRemote, testConnection } from './s3.ts';
+import { deleteKeys, getObjectStream, listBackups, pruneRemote, testConnection } from './s3.ts';
 
 function fakeClient(handler: (command: unknown) => unknown): S3Client {
 	return { send: vi.fn(async (command: unknown) => handler(command)) } as unknown as S3Client;
@@ -88,6 +90,39 @@ describe('pruneRemote', () => {
 		const count = await pruneRemote(client, { bucket: 'b', prefix: '', keep: 1 });
 		expect(count).toBe(1);
 		expect(deleted).toEqual(['strongs-20260101-030000.dump']);
+	});
+});
+
+describe('getObjectStream', () => {
+	it('requests the given bucket and key and returns the body and content length', async () => {
+		const client = fakeClient((command) => {
+			expect(command).toBeInstanceOf(GetObjectCommand);
+			const input = (command as GetObjectCommand).input;
+			expect(input.Bucket).toBe('b');
+			expect(input.Key).toBe('strongs/strongs-20260101-030000.dump');
+			return { Body: Readable.from(Buffer.from('PGDMP')), ContentLength: 5 };
+		});
+		const { body, sizeBytes } = await getObjectStream(client, {
+			bucket: 'b',
+			key: 'strongs/strongs-20260101-030000.dump'
+		});
+		expect(sizeBytes).toBe(5);
+		const chunks: Buffer[] = [];
+		for await (const chunk of body) chunks.push(chunk as Buffer);
+		expect(Buffer.concat(chunks).toString('ascii')).toBe('PGDMP');
+	});
+
+	it('defaults sizeBytes to 0 when the response has no ContentLength', async () => {
+		const client = fakeClient(() => ({ Body: Readable.from(Buffer.from('x')) }));
+		const { sizeBytes } = await getObjectStream(client, { bucket: 'b', key: 'k' });
+		expect(sizeBytes).toBe(0);
+	});
+
+	it('throws when the response has no body', async () => {
+		const client = fakeClient(() => ({}));
+		await expect(getObjectStream(client, { bucket: 'b', key: 'k' })).rejects.toThrow(
+			'Das S3-Objekt hat keinen Inhalt.'
+		);
 	});
 });
 

--- a/src/lib/server/backup/s3.ts
+++ b/src/lib/server/backup/s3.ts
@@ -7,8 +7,10 @@
  */
 
 import { createReadStream } from 'node:fs';
+import type { Readable } from 'node:stream';
 import {
 	DeleteObjectsCommand,
+	GetObjectCommand,
 	HeadBucketCommand,
 	ListObjectsV2Command,
 	PutObjectCommand,
@@ -59,6 +61,23 @@ export async function uploadFile(
 		});
 	}
 	await upload.done();
+}
+
+/**
+ * Streams a single object back rather than buffering it, so a large dump does not sit in memory
+ * before being forwarded to the browser — the download/restore counterpart of `uploadFile`.
+ */
+export async function getObjectStream(
+	client: S3Client,
+	options: { bucket: string; key: string }
+): Promise<{ body: Readable; sizeBytes: number }> {
+	const result = await client.send(
+		new GetObjectCommand({ Bucket: options.bucket, Key: options.key })
+	);
+	if (!result.Body) throw new Error('Das S3-Objekt hat keinen Inhalt.');
+	// The Node.js runtime of the SDK always resolves `Body` to a `Readable`; only the browser runtime
+	// would give a web `ReadableStream` instead, which does not apply here.
+	return { body: result.Body as Readable, sizeBytes: result.ContentLength ?? 0 };
 }
 
 /** Paginated listing of every object under `prefix`. */

--- a/src/routes/admin/backup/+page.server.ts
+++ b/src/routes/admin/backup/+page.server.ts
@@ -20,7 +20,9 @@ import {
 	listLocalBackups,
 	runRestore,
 	runScheduledBackup,
-	stagedDumpPath
+	stagedDumpPath,
+	stageFromLocal,
+	stageFromS3
 } from '$lib/server/backup/jobs';
 import { hasPgTools, isCustomFormatDump } from '$lib/server/backup/pg';
 import {
@@ -32,6 +34,11 @@ import { selectExpired } from '$lib/server/backup/retention';
 
 /** Typed confirmation the restore form requires before a restore is allowed to proceed. */
 const RESTORE_CONFIRMATION = 'WIEDERHERSTELLEN';
+
+/** Same server-side check for every restore action, whichever source the file comes from. */
+function isConfirmed(form: FormData): boolean {
+	return String(form.get('confirm') ?? '').trim() === RESTORE_CONFIRMATION;
+}
 
 function clampInt(
 	value: FormDataEntryValue | null,
@@ -213,25 +220,30 @@ export const actions = {
 		}
 	},
 
+	// The three restore actions below all report failure through the dedicated `restoreError` key
+	// (rather than the generic `error` key `saveSettings`/`deleteLocal` use) so the "Wiederherstellen"
+	// section is the only place that ever renders one of their messages — otherwise a restore failure
+	// would render twice, once there and once in the unrelated S3-settings error banner above.
+
 	restore: async ({ request, locals }) => {
 		const form = await request.formData();
 
 		// The server-side check that matters; the client-side disabled button is convenience only.
-		if (String(form.get('confirm') ?? '').trim() !== RESTORE_CONFIRMATION) {
-			return fail(400, { error: 'confirm' });
+		if (!isConfirmed(form)) {
+			return fail(400, { restoreError: 'confirm' });
 		}
 
 		let path: string;
 		try {
 			path = stagedDumpPath(String(form.get('stagedId') ?? ''));
 		} catch {
-			return fail(400, { error: 'Ungültige hochgeladene Datei. Bitte erneut hochladen.' });
+			return fail(400, { restoreError: 'Ungültige hochgeladene Datei. Bitte erneut hochladen.' });
 		}
 
 		const stats = await stat(path).catch(() => null);
 		if (!stats || stats.size === 0) {
 			return fail(400, {
-				error: 'Die hochgeladene Datei wurde nicht gefunden. Bitte erneut hochladen.'
+				restoreError: 'Die hochgeladene Datei wurde nicht gefunden. Bitte erneut hochladen.'
 			});
 		}
 
@@ -240,12 +252,79 @@ export const actions = {
 		await handle.read(head, 0, 5, 0);
 		await handle.close();
 		if (!isCustomFormatDump(head)) {
-			return fail(400, { error: 'Das ist keine gültige Backup-Datei.' });
+			return fail(400, { restoreError: 'Das ist keine gültige Backup-Datei.' });
 		}
 
 		const db = getDb();
 		if (await hasRunningBackupJob(db)) {
-			return fail(409, { error: 'Es läuft bereits ein Backup- oder Wiederherstellungsvorgang.' });
+			return fail(409, {
+				restoreError: 'Es läuft bereits ein Backup- oder Wiederherstellungsvorgang.'
+			});
+		}
+
+		await runRestore(db, { path, createdBy: locals.user!.id });
+		return { restoreStarted: true };
+	},
+
+	/** Restores directly from an existing local copy — no download + re-upload detour. */
+	restoreLocal: async ({ request, locals }) => {
+		const form = await request.formData();
+		if (!isConfirmed(form)) {
+			return fail(400, { restoreError: 'confirm' });
+		}
+
+		const db = getDb();
+		if (await hasRunningBackupJob(db)) {
+			return fail(409, {
+				restoreError: 'Es läuft bereits ein Backup- oder Wiederherstellungsvorgang.'
+			});
+		}
+
+		let path: string;
+		try {
+			path = await stageFromLocal(String(form.get('name') ?? ''));
+		} catch (error) {
+			return fail(400, {
+				restoreError:
+					error instanceof Error ? error.message : 'Die lokale Sicherung wurde nicht gefunden.'
+			});
+		}
+
+		await runRestore(db, { path, createdBy: locals.user!.id });
+		return { restoreStarted: true };
+	},
+
+	/** Restores directly from an S3 object — no download + re-upload detour. */
+	restoreS3: async ({ request, locals }) => {
+		const form = await request.formData();
+		if (!isConfirmed(form)) {
+			return fail(400, { restoreError: 'confirm' });
+		}
+
+		const key = String(form.get('key') ?? '');
+		if (!key) return fail(400, { restoreError: 'Fehlender Schlüssel.' });
+
+		const db = getDb();
+		if (await hasRunningBackupJob(db)) {
+			return fail(409, {
+				restoreError: 'Es läuft bereits ein Backup- oder Wiederherstellungsvorgang.'
+			});
+		}
+
+		const { settings, secretAccessKey } = await readBackupCredentials(db);
+		if (!settings.s3.bucket || !secretAccessKey) {
+			return fail(400, { restoreError: 'S3 ist nicht vollständig konfiguriert.' });
+		}
+
+		let path: string;
+		try {
+			const client = createS3Client({ ...settings.s3, secretAccessKey });
+			path = await stageFromS3(client, { bucket: settings.s3.bucket, key });
+		} catch (error) {
+			return fail(400, {
+				restoreError:
+					error instanceof Error ? error.message : 'Herunterladen von S3 fehlgeschlagen.'
+			});
 		}
 
 		await runRestore(db, { path, createdBy: locals.user!.id });

--- a/src/routes/admin/backup/+page.svelte
+++ b/src/routes/admin/backup/+page.svelte
@@ -109,7 +109,8 @@
 		xhr.send(file);
 	}
 
-	const canRestore = $derived(stagedId !== '' && confirmText === data.restorePhrase);
+	const confirmMatches = $derived(confirmText === data.restorePhrase);
+	const canRestore = $derived(stagedId !== '' && confirmMatches);
 </script>
 
 <svelte:head><title>Backup — strongs.de</title></svelte:head>
@@ -130,6 +131,33 @@
 		Verfügung, wenn das Image die PostgreSQL-Client-Tools enthält.
 	</p>
 {/if}
+
+<!-- Bestätigung für Wiederherstellung — gilt für jede Wiederherstellen-Aktion auf dieser Seite: den
+     Datei-Upload unten, sowie "direkt wiederherstellen" bei den lokalen Kopien und den S3-Objekten. -->
+<section class="mb-8 max-w-2xl rounded-lg border border-red-300 p-4 dark:border-red-900">
+	<h2 class="mb-2 text-sm font-semibold tracking-wide text-red-700 uppercase dark:text-red-300">
+		Bestätigung für Wiederherstellung
+	</h2>
+	<p class="mb-3 text-sm text-stone-600 dark:text-stone-300">
+		Gilt für jede Wiederherstellung auf dieser Seite. Eine Wiederherstellung ersetzt den gesamten
+		Inhalt der Datenbank durch den Inhalt der gewählten Backup-Datei; vorher wird automatisch eine
+		Sicherung des aktuellen Zustands erstellt.
+	</p>
+	<label class="mb-1 block text-xs font-medium" for="confirm-global">
+		Zur Bestätigung <span class="font-mono">{data.restorePhrase}</span> eingeben:
+	</label>
+	<input
+		id="confirm-global"
+		bind:value={confirmText}
+		autocomplete="off"
+		class="w-full max-w-sm rounded-md border border-stone-300 px-2 py-1.5 text-sm dark:border-stone-700 dark:bg-stone-900"
+	/>
+	{#if form?.restoreError === 'confirm'}
+		<p class="mt-2 text-sm text-red-700 dark:text-red-300" role="alert">
+			Die Bestätigung stimmt nicht überein.
+		</p>
+	{/if}
+</section>
 
 <!-- Sofort-Backup -->
 <section class="mb-8 max-w-2xl rounded-lg border border-stone-200 p-4 dark:border-stone-800">
@@ -430,14 +458,36 @@
 			</h3>
 			<ul class="space-y-1 text-sm">
 				{#each data.localBackups as backup (backup.name)}
-					<li class="flex items-center justify-between gap-2">
+					<li class="flex flex-wrap items-center justify-between gap-2">
 						<span>{backup.name} — {formatBytes(backup.size)}</span>
-						<form method="POST" action="?/deleteLocal">
-							<input type="hidden" name="name" value={backup.name} />
-							<button type="submit" class="text-xs text-red-700 underline dark:text-red-300">
-								löschen
-							</button>
-						</form>
+						<div class="flex items-center gap-3">
+							<!-- data-sveltekit-reload: see the note on the "Sofort-Backup" download link above. -->
+							<a
+								href={`/admin/backup/download/local/${backup.name}`}
+								data-sveltekit-reload
+								class="text-xs text-accent-700 underline dark:text-accent-300"
+							>
+								herunterladen
+							</a>
+							<form method="POST" action="?/restoreLocal">
+								<input type="hidden" name="name" value={backup.name} />
+								<input type="hidden" name="confirm" value={confirmText} />
+								<button
+									type="submit"
+									disabled={!confirmMatches || running}
+									class="text-xs text-red-700 underline enabled:hover:text-red-800
+									       disabled:opacity-50 dark:text-red-300"
+								>
+									direkt wiederherstellen
+								</button>
+							</form>
+							<form method="POST" action="?/deleteLocal">
+								<input type="hidden" name="name" value={backup.name} />
+								<button type="submit" class="text-xs text-red-700 underline dark:text-red-300">
+									löschen
+								</button>
+							</form>
+						</div>
 					</li>
 				{/each}
 			</ul>
@@ -458,24 +508,51 @@
 			<p class="mt-2 text-xs text-red-700 dark:text-red-300">{form.remoteError}</p>
 		{/if}
 		{#if form?.remote}
-			<table class="mt-2 w-full text-xs">
-				<thead>
-					<tr class="text-left text-stone-500 dark:text-stone-400">
-						<th class="pb-1 font-medium">Datei</th>
-						<th class="pb-1 font-medium">Größe</th>
-						<th class="pb-1 font-medium">Datum</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each form.remote as object (object.key)}
-						<tr class:opacity-50={object.expired}>
-							<td class="py-0.5">{object.key}</td>
-							<td class="py-0.5">{formatBytes(object.size)}</td>
-							<td class="py-0.5">{dateFormat.format(new Date(object.lastModified))}</td>
+			<div class="overflow-x-auto">
+				<table class="mt-2 w-full text-xs">
+					<thead>
+						<tr class="text-left text-stone-500 dark:text-stone-400">
+							<th class="pb-1 font-medium">Datei</th>
+							<th class="pb-1 font-medium">Größe</th>
+							<th class="pb-1 font-medium">Datum</th>
+							<th class="pb-1 font-medium"></th>
+							<th class="pb-1 font-medium"></th>
 						</tr>
-					{/each}
-				</tbody>
-			</table>
+					</thead>
+					<tbody>
+						{#each form.remote as object (object.key)}
+							<tr class:opacity-50={object.expired}>
+								<td class="py-0.5">{object.key}</td>
+								<td class="py-0.5">{formatBytes(object.size)}</td>
+								<td class="py-0.5">{dateFormat.format(new Date(object.lastModified))}</td>
+								<td class="py-0.5 text-right whitespace-nowrap">
+									<a
+										href={`/admin/backup/download/s3?key=${encodeURIComponent(object.key)}`}
+										data-sveltekit-reload
+										class="text-accent-700 underline dark:text-accent-300"
+									>
+										herunterladen
+									</a>
+								</td>
+								<td class="py-0.5 text-right whitespace-nowrap">
+									<form method="POST" action="?/restoreS3">
+										<input type="hidden" name="key" value={object.key} />
+										<input type="hidden" name="confirm" value={confirmText} />
+										<button
+											type="submit"
+											disabled={!confirmMatches || running}
+											class="text-red-700 underline enabled:hover:text-red-800
+											       disabled:opacity-50 dark:text-red-300"
+										>
+											direkt wiederherstellen
+										</button>
+									</form>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
 		{/if}
 	</div>
 </section>
@@ -498,12 +575,8 @@
 		Stand des Backups. Möglicherweise musst du dich anschließend neu anmelden.
 	</p>
 
-	{#if form?.error === 'confirm'}
-		<p class="mb-3 text-sm text-red-700 dark:text-red-300" role="alert">
-			Die Bestätigung stimmt nicht überein.
-		</p>
-	{:else if form?.error && typeof form.error === 'string'}
-		<p class="mb-3 text-sm text-red-700 dark:text-red-300" role="alert">{form.error}</p>
+	{#if form?.restoreError && form.restoreError !== 'confirm' && typeof form.restoreError === 'string'}
+		<p class="mb-3 text-sm text-red-700 dark:text-red-300" role="alert">{form.restoreError}</p>
 	{/if}
 	{#if form?.restoreStarted}
 		<p class="mb-3 text-sm">
@@ -532,18 +605,8 @@
 			{/if}
 		</div>
 		<input type="hidden" name="stagedId" value={stagedId} />
-
-		<div>
-			<label class="mb-1 block text-xs font-medium" for="confirm">
-				Zur Bestätigung <span class="font-mono">{data.restorePhrase}</span> eingeben:
-			</label>
-			<input
-				id="confirm"
-				name="confirm"
-				bind:value={confirmText}
-				class="w-full rounded-md border border-stone-300 px-2 py-1.5 text-sm dark:border-stone-700 dark:bg-stone-900"
-			/>
-		</div>
+		<input type="hidden" name="confirm" value={confirmText} />
+		<p class="text-xs text-stone-500 dark:text-stone-400">Bestätigungsphrase siehe oben.</p>
 
 		<button
 			type="submit"

--- a/src/routes/admin/backup/download/local/[name]/+server.ts
+++ b/src/routes/admin/backup/download/local/[name]/+server.ts
@@ -1,0 +1,41 @@
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { error } from '@sveltejs/kit';
+import { config } from '$lib/server/config';
+import { BACKUP_FILE_PATTERN } from '$lib/server/backup/retention';
+
+export const prerender = false;
+
+/**
+ * Downloads an existing local backup copy (kept by the scheduled S3 backup as a safety net) — still
+ * protected by the `/admin` guard in `hooks.server.ts`.
+ *
+ * Unlike `/admin/backup/download` (which dumps a fresh, throwaway copy and deletes it after
+ * streaming), this serves an already-existing, durable local file and never deletes it.
+ *
+ * `params.name` is checked against `BACKUP_FILE_PATTERN` before it is ever joined into a path — the
+ * pattern allows neither `/` nor `..`, which is what rules out path traversal here; string
+ * concatenation is deliberately avoided.
+ */
+export async function GET({ params }) {
+	const { name } = params;
+	if (!name || !BACKUP_FILE_PATTERN.test(name)) {
+		error(400, 'Ungültiger Dateiname.');
+	}
+
+	const path = join(config().BACKUP_TMP_DIR, name);
+	const stats = await stat(path).catch(() => null);
+	if (!stats) error(404, 'Datei nicht gefunden.');
+
+	const nodeStream = createReadStream(path);
+	return new Response(Readable.toWeb(nodeStream) as ReadableStream, {
+		headers: {
+			'content-type': 'application/octet-stream',
+			'content-disposition': `attachment; filename="${name}"`,
+			'content-length': String(stats.size),
+			'cache-control': 'no-store'
+		}
+	});
+}

--- a/src/routes/admin/backup/download/s3/+server.ts
+++ b/src/routes/admin/backup/download/s3/+server.ts
@@ -1,0 +1,41 @@
+import { Readable } from 'node:stream';
+import { error } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db';
+import { readBackupCredentials } from '$lib/server/backup/settings';
+import { createS3Client, getObjectStream } from '$lib/server/backup/s3';
+
+export const prerender = false;
+
+/**
+ * Downloads a single S3 backup object directly — still protected by the `/admin` guard in
+ * `hooks.server.ts`. `key` is a query parameter rather than a path segment because S3 keys contain
+ * `/` (the configured prefix, and `pre-restore/`).
+ */
+export async function GET({ url }) {
+	const key = url.searchParams.get('key');
+	if (!key) error(400, 'Fehlender Parameter "key".');
+
+	const db = getDb();
+	const { settings, secretAccessKey } = await readBackupCredentials(db);
+	if (!settings.s3.bucket || !secretAccessKey) {
+		error(400, 'S3 ist nicht vollständig konfiguriert.');
+	}
+
+	const client = createS3Client({ ...settings.s3, secretAccessKey });
+	let stream: { body: Readable; sizeBytes: number };
+	try {
+		stream = await getObjectStream(client, { bucket: settings.s3.bucket, key });
+	} catch (err) {
+		error(502, err instanceof Error ? err.message : 'Herunterladen von S3 fehlgeschlagen.');
+	}
+
+	const fileName = key.slice(key.lastIndexOf('/') + 1) || 'backup.dump';
+	return new Response(Readable.toWeb(stream.body) as ReadableStream, {
+		headers: {
+			'content-type': 'application/octet-stream',
+			'content-disposition': `attachment; filename="${fileName}"`,
+			...(stream.sizeBytes ? { 'content-length': String(stream.sizeBytes) } : {}),
+			'cache-control': 'no-store'
+		}
+	});
+}


### PR DESCRIPTION
## Summary

Todo.md #8: "Es soll auch möglich sein, lokale oder S3-Backups herunterzuladen und auch direkt wiederherzustellen. Momentan müsste man immer erst in S3 sich einloggen, die Datei herunterladen und dann wieder hochladen um eine Wiederherstellung anzutriggern."

Backup/Restore-Grundinfrastruktur (S3-Client, Verschlüsselung, Scheduler, Retention, Job-Historie, typisierte Restore-Bestätigung) existierte bereits vollständig. Diese PR schließt die verbleibende Lücke:

- `s3.ts`: `getObjectStream()` — streamt ein einzelnes S3-Objekt (Pendant zu `uploadFile`).
- `jobs.ts`: `stageFromLocal(name)`/`stageFromS3(client, {bucket,key})` — erzeugen immer eine **Kopie** in einem frischen Staging-Pfad, nie den Original-Pfad direkt, da `runRestore`s Cleanup den übergebenen Pfad unconditional löscht.
- Neue Download-Routen `admin/backup/download/local/[name]` und `admin/backup/download/s3?key=` — mit Path-Traversal-Schutz (striktes Filename-Pattern) bzw. Streaming über den S3-Client.
- Neue `restoreLocal`/`restoreS3`-Actions in `admin/backup/+page.server.ts` — gleiche Typed-Confirmation (`WIEDERHERSTELLEN`) wie die bestehende Upload-Restore-Action, keine Abschwächung der Sicherheitsprüfung.
- UI: Download- und "Direkt wiederherstellen"-Buttons pro Zeile in der Liste lokaler Kopien und der S3-Objekttabelle, über dieselbe Bestätigungsphrase gesteuert wie der bestehende Upload-Restore-Weg.
- Nebenbei einen Anzeige-Bug gefixt: Restore-Fehler wurden doppelt angezeigt, weil sie sich einen Fehler-Key mit den S3-Settings teilten — jetzt ein eigener `restoreError`-Key.

**Bewusst nicht per e2e getestet:** der vollständige S3-Restore-Rundlauf (kein Bucket in dieser Umgebung/CI verfügbar) — dafür mit gemockten `S3Client`-Unit-Tests in `s3.spec.ts`/`jobs.spec.ts` abgedeckt (ungültiger Name, fehlende Datei, falsche Magic Bytes, Stream-Fehler, Original-Datei bleibt unangetastet).

## Test plan

- [x] `pnpm check` — 0 Fehler
- [x] `pnpm lint` — clean
- [x] `pnpm test:unit` — 333/333
- [x] `pnpm test:e2e` — 69/70 (1 vorbestehender Skip wegen fehlendem `pg_dump`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)