### PR TITLE
Publish container image before deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,21 +90,38 @@ jobs:
           retention-days: 7
 
   image:
-    name: Build container image
+    name: Build and publish container image
+    needs: [check, e2e]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          # Pull requests and rewrite branches verify that the image builds. Only a successful push
+          # to main publishes deployable tags.
+          push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+          tags: |
+            ghcr.io/akribos-biblestudy/akribos:latest
+            ghcr.io/akribos-biblestudy/akribos:${{ github.sha }}
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   deploy:
     name: Deploy to Coolify
-    needs: [check, e2e, image]
+    needs: [image]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     # Set COOLIFY_WEBHOOK (the resource's deploy webhook URL) and COOLIFY_TOKEN as repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@ werden. Ausführlichere Hintergrundtexte liegen in `docs/architecture.md`, `docs
 Akribos ist eine SvelteKit-5-Anwendung (Runes) mit TypeScript, PostgreSQL/Drizzle und einem Node-Adapter.
 Paketmanager ist `pnpm` (Node >= 24).
 
+Das Produktionsimage wird nach erfolgreichen CI-Tests von GitHub Actions nach
+`ghcr.io/akribos-biblestudy/akribos` veröffentlicht. `compose.yaml` darf für den App-Service kein
+`build:` enthalten: Coolify zieht ausschließlich das vorgebaute Image und löst den Deploy erst über
+den nachgelagerten Actions-Webhook aus.
+
 - `pnpm check`: Svelte- und TypeScript-Prüfung
 - `pnpm lint`: Prettier-Check und ESLint
 - `pnpm test:unit --run`: Unit-Tests

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ warnings the bundled files produce.
 
 ## Deployment
 
-`compose.yaml` is the production stack: the app and PostgreSQL. Backup and restore are handled by the
-app itself, from `/admin/backup` — see below.
+`compose.yaml` is the production stack: the prebuilt app image and PostgreSQL. Backup and restore are
+handled by the app itself, from `/admin/backup` — see below.
 
 In Coolify, add a **Docker Compose** resource pointing at this repository, assign a domain to the
 `app` service, and set these environment variables:
@@ -82,8 +82,11 @@ In Coolify, add a **Docker Compose** resource pointing at this repository, assig
 | `MAIL_FROM`                 | sender address, must be verified in Brevo                    |
 | `BOOTSTRAP_ADMIN_EMAIL`     | the first account registered with this address gets admin    |
 
-Migrations run automatically on container start. Pushes to `main` trigger a deploy through the
-Coolify webhook once `COOLIFY_WEBHOOK` and `COOLIFY_TOKEN` are set as repository secrets.
+Migrations run automatically on container start. After a push to `main` passes CI, GitHub Actions
+publishes `ghcr.io/akribos-biblestudy/akribos:latest` and only then triggers the Coolify webhook.
+Coolify pulls that image instead of building it on the production server. Set `COOLIFY_WEBHOOK` and
+`COOLIFY_TOKEN` as repository secrets; GHCR access and the complete first-time setup are documented in
+[docs/operations.md](docs/operations.md#container-registry-and-automatic-deployment).
 
 Backup, restore and upgrade procedures are in [docs/operations.md](docs/operations.md); the design and
 the reasoning behind it are in [docs/architecture.md](docs/architecture.md).

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,9 +4,10 @@
 # itself with `pnpm dev`.
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Built by GitHub Actions after the test suite passes. Coolify must only pull this image; keeping
+    # a `build:` section here would move the memory-intensive application build back onto the server.
+    image: ghcr.io/akribos-biblestudy/akribos:latest
+    pull_policy: always
     restart: unless-stopped
     depends_on:
       db:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,8 +2,12 @@
 
 ## Deploying
 
-`compose.yaml` is the whole stack: the app and PostgreSQL 17. Add it in Coolify as a **Docker
-Compose** resource, assign a domain to the `app` service, and set:
+`compose.yaml` is the whole stack: the app and PostgreSQL 17. The application image is built on
+GitHub's runners and published as `ghcr.io/akribos-biblestudy/akribos:latest`; the production server
+never builds it itself.
+
+Add the repository in Coolify as a **Docker Compose** resource with branch `main`, base directory `/`
+and compose location `/compose.yaml`, then assign a domain to the `app` service and set:
 
 | Variable                    | Where it comes from                                                     |
 | --------------------------- | ----------------------------------------------------------------------- |
@@ -17,6 +21,36 @@ Compose** resource, assign a domain to the `app` service, and set:
 Migrations run in the container's entrypoint before the server starts, so a deploy that changes the
 schema needs nothing extra. A failed migration stops the boot, and the healthcheck keeps the old
 container serving.
+
+### Container registry and automatic deployment
+
+The `image` job in `.github/workflows/ci.yml` runs after lint, type, unit and end-to-end tests. On a
+push to `main` it publishes two GHCR tags: `latest` for Coolify and the full Git commit SHA for an
+immutable rollback reference. Only after that push succeeds does the `deploy` job call Coolify. Set
+these repository secrets under **Settings → Secrets and variables → Actions**:
+
+| Secret            | Value                                                         |
+| ----------------- | ------------------------------------------------------------- |
+| `COOLIFY_WEBHOOK` | the deploy webhook URL shown by this Coolify resource         |
+| `COOLIFY_TOKEN`   | a Coolify API token; API access must be enabled on the server |
+
+Do not add a `build:` section for `app` back to `compose.yaml`: that makes Coolify compile the app on
+the production server. `pull_policy: always` makes every deployment refresh the moving `latest` tag.
+Disable Coolify's direct auto-deploy-on-push integration if it is enabled; otherwise it can deploy
+once before GitHub Actions has published the new image. The Actions webhook is the intended trigger.
+
+GHCR packages are private when first created. Before the first deployment, authenticate Docker on
+the Coolify server with a GitHub personal access token (classic) that has only `read:packages`:
+
+```sh
+read -rsp "GHCR token: " GHCR_READ_TOKEN; echo
+printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
+unset GHCR_READ_TOKEN
+```
+
+Alternatively, after the first successful publish, change the `akribos` package visibility to
+**Public** on GitHub; public GHCR images can be pulled anonymously. If the first automatic deployment
+ran before registry access was configured, use Coolify's **Redeploy** button once afterward.
 
 ### First deployment
 
@@ -64,7 +98,8 @@ uploads are archived in the `uploads` volume — back that up too, or keep the s
 
 ## Upgrading
 
-**Application**: push, and Coolify redeploys. Migrations run on boot.
+**Application**: merge to `main`. GitHub Actions tests the commit, builds and publishes the image, and
+then asks Coolify to redeploy it. Coolify pulls the image; migrations run on boot.
 
 **PostgreSQL major version**: the data directory is not compatible across major versions, so dump,
 recreate and restore:

--- a/e2e/account.e2e.ts
+++ b/e2e/account.e2e.ts
@@ -167,6 +167,10 @@ test('a verse list keeps its verses and notes', async ({ page }) => {
 	await editor.click();
 	await editor.fill('Der bekannteste Vers');
 	await noteForm.getByRole('button', { name: 'Speichern' }).click();
+	// The enhanced form action completes asynchronously; wait for its saved state before reloading.
+	await expect(page.getByRole('button', { name: 'Kommentar bearbeiten' })).toContainText(
+		'Der bekannteste Vers'
+	);
 
 	// The note survives a reload.
 	await page.reload();


### PR DESCRIPTION
## What changed

- publish the application image to GHCR after CI succeeds on `main`
- tag images as both `latest` and the immutable commit SHA
- make Coolify pull the prebuilt image instead of building it on the production server
- trigger the Coolify webhook only after the image was published
- document GHCR authentication, Coolify setup, and the deployment sequence
- stabilize the verse-list note E2E test by waiting for the enhanced save action before reloading

## Why

The production server is resource-constrained. `compose.yaml` previously contained a `build:` section, while the GitHub Actions image job used `push: false`. As a result, GitHub verified an image build but Coolify repeated the memory-intensive build locally during every deployment.

## Impact

Merges to `main` now build on GitHub-hosted runners. Coolify only downloads and starts the resulting `ghcr.io/akribos-biblestudy/akribos:latest` image. Existing volumes, database configuration, environment variables, migrations, and health checks remain unchanged.

## Validation

- `pnpm check`
- Prettier check for all changed files
- ESLint (excluding untracked local `.claude/worktrees` artifacts)
- `docker compose config --quiet`
- targeted verse-list E2E regression test
- full E2E suite serially: 85 passed
