### PR TITLE
Fix reader sidebar history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,15 @@ Wichtige Scroll-Invarianten:
   Berechnung aus dem nachträglichen Wert kompensiert doppelt und erzeugt Sprünge.
 - Die URL wird beim Lesen mit `replaceState` nachgeführt. `reader-location.svelte.ts` koppelt diese
   Position an das Suchfeld, ohne eine Servernavigation auszulösen.
+- Nach einer echten Reader-Navigation müssen verzögerte Scroll-/Adressleisten-Timer und noch laufende
+  Kapitel-Nachladungen verworfen werden; sie dürfen niemals den neuen Kapitelstream oder dessen URL
+  verändern. Die Strong-Seitenleiste wird nach History-Navigationen aus `window.location.hash`
+  restauriert, weil flache `replaceState`-Änderungen nicht zuverlässig in `page.url` reaktiv werden.
+- Jeder Klick auf ein Strong-Wort und jedes explizite Schließen der Strong-Seitenleiste legt mit
+  `pushState` einen eigenen History-Eintrag an. Dadurch kann Zurück/Vorwärts jeden einzelnen
+  Sidebar-Zustand wiederherstellen; Scroll-Aktionen aktualisieren die URL dagegen weiterhin nur mit
+  `replaceState`. Da Zurück/Vorwärts zwischen flachen History-Einträgen keine SvelteKit-Navigation
+  auslöst, synchronisiert zusätzlich ein `popstate`-Handler die Seitenleiste mit dem aktuellen Hash.
 - Vers 1 hat absichtlich keine sichtbare Versnummer. Die sichtbare `.flow-chapter-number` ist deshalb
   ein Link und öffnet über `onVerseNumberClick()` dasselbe `VerseMenu` für den ersten Vers. Sie darf
   nicht wieder in ein rein dekoratives `span` umgewandelt werden.

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -454,6 +454,77 @@ test('clicking a tagged word opens the study sidebar', async ({ page }) => {
 	await expect(page).toHaveURL(/#G25\/geliebt\/16$/);
 });
 
+test('browser back restores a previously opened study sidebar', async ({ page }) => {
+	await page.goto('/Joh3');
+	await page.locator('button.strong[data-strong="G25"]').first().click();
+	await expect(page.getByRole('complementary')).toContainText('G25');
+
+	await page.getByRole('searchbox').fill('1Mo 1');
+	await page.getByRole('searchbox').press('Enter');
+	await expect(page).toHaveURL(/\/1Mo1$/);
+
+	await page.goBack();
+	await expect(page).toHaveURL(/\/Joh3#G25\/geliebt\/16$/);
+	await expect(page.getByRole('complementary')).toBeVisible();
+	await expect(page.getByRole('complementary')).toContainText('G25');
+});
+
+test('browser history tracks every Strong click and explicit sidebar close', async ({ page }) => {
+	await page.goto('/');
+	await page.locator('a.nav-cta').click();
+	await expect(page).toHaveURL(/\/Joh3$/);
+
+	await page.locator('button.strong[data-strong="G25"]').first().click();
+	await expect(page).toHaveURL(/#G25\/geliebt\/16$/);
+	await expect(page.getByRole('complementary')).toContainText('G25');
+
+	await page.locator('button.strong[data-strong="G2316"]').first().click();
+	await expect(page).toHaveURL(/#G2316\/Gott\/16$/);
+	await expect(page.getByRole('complementary')).toContainText('G2316');
+
+	await page.getByRole('complementary').getByRole('button', { name: 'Schließen' }).click();
+	await expect(page).toHaveURL(/\/Joh3$/);
+	await expect(page.getByRole('complementary')).not.toBeVisible();
+
+	await page.goBack();
+	await expect(page).toHaveURL(/#G2316\/Gott\/16$/);
+	await expect(page.getByRole('complementary')).toContainText('G2316');
+
+	await page.goBack();
+	await expect(page).toHaveURL(/#G25\/geliebt\/16$/);
+	await expect(page.getByRole('complementary')).toContainText('G25');
+
+	await page.goBack();
+	await expect(page).toHaveURL(/\/Joh3$/);
+	await expect(page.getByRole('complementary')).not.toBeVisible();
+
+	await page.goBack();
+	await expect(page).toHaveURL(/\/$/);
+	await expect(page.getByRole('heading', { level: 1 })).toContainText('Lies den Text');
+});
+
+test('a pending reader position update cannot overwrite a search navigation', async ({ page }) => {
+	await page.setViewportSize({ width: 900, height: 300 });
+	await page.goto('/Joh3');
+
+	const column = page.locator('.flow-column').first();
+	await column.evaluate((element) => {
+		const target = element.querySelector<HTMLElement>('[data-verse-key="43:3:17"]');
+		if (!target) throw new Error('fixture verse 17 is missing');
+		element.scrollTop = target.offsetTop;
+		element.dispatchEvent(new Event('scroll'));
+	});
+	// Cross-column alignment runs after 150 ms and then leaves a debounced address-bar update queued.
+	await page.waitForTimeout(175);
+
+	await page.getByRole('searchbox').fill('1Mo 1');
+	await page.getByRole('searchbox').press('Enter');
+	await expect(page).toHaveURL(/\/1Mo1$/);
+	await page.waitForTimeout(400);
+	// The new reader may add its visible first verse, but stale work from John must never take over.
+	await expect(page).toHaveURL(/\/1Mo1(?:,1)?$/);
+});
+
 test('clicking a footnote marker opens its note without relying on the Popover API', async ({
 	page
 }) => {

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-	import { replaceState } from '$app/navigation';
+	import { afterNavigate, beforeNavigate, pushState, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
-	import { tick } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { formatReference, referencePath, type VerseRef } from '$lib/bible/reference';
 	import { segmentsToText, splitVerseLead } from '$lib/bible/segments';
@@ -382,9 +382,15 @@
 	/** Strong's number shown in the study sidebar, kept in the URL hash so it can be shared. */
 	let activeStrong = $state<{ strong: string; word: string; reference: string } | null>(null);
 
-	// Restore the sidebar from the hash on load and on navigation.
-	$effect(() => {
-		const hash = page.url.hash.replace(/^#/, '');
+	/**
+	 * Restores the sidebar from the browser's real URL after a navigation.
+	 *
+	 * The reader also changes its address with shallow `replaceState` calls. Those deliberately do not
+	 * make `page.url` reactive, so a later history traversal must read `window.location` rather than a
+	 * potentially stale route URL.
+	 */
+	function restoreStrongFromHash(hashValue: string) {
+		const hash = hashValue.replace(/^#/, '');
 		if (!hash) {
 			activeStrong = null;
 			return;
@@ -406,7 +412,9 @@
 				})
 			};
 		}
-	});
+	}
+
+	afterNavigate(() => restoreStrongFromHash(window.location.hash));
 
 	function openStrong(
 		strong: string,
@@ -424,15 +432,16 @@
 				verse
 			})
 		};
-		replaceState(
-			`${page.url.pathname}#${encodeURIComponent(strong)}/${encodeURIComponent(word)}/${verse}`,
-			page.state
-		);
+		const url = `${window.location.pathname}${window.location.search}#${encodeURIComponent(strong)}/${encodeURIComponent(word)}/${verse}`;
+		pushState(url, { ...page.state, studySidebar: true });
 	}
 
 	function closeStrong() {
 		activeStrong = null;
-		replaceState(page.url.pathname, page.state);
+		pushState(`${window.location.pathname}${window.location.search}`, {
+			...page.state,
+			studySidebar: false
+		});
 	}
 
 	const previousPath = $derived(
@@ -562,6 +571,8 @@
 	let streamSignature = '';
 	let streamColumnsKey = data.columns.map((column) => column.resource.id).join(',');
 	let jumpedSignature = '';
+	/** Invalidates chapter requests that were started for an earlier reader navigation. */
+	let streamGeneration = 0;
 	/**
 	 * Columns whose next scroll events were caused by our own alignment/prepend compensation.
 	 *
@@ -594,6 +605,10 @@
 		const columnsKey = data.columns.map((column) => column.resource.id).join(',');
 		const signature = `${data.reference.book}:${data.reference.chapter}:${columnsKey}`;
 		if (signature !== streamSignature) {
+			streamGeneration += 1;
+			loadingPrevious = false;
+			loadingNext = false;
+			cancelScheduledReaderWork();
 			const columnsChanged = columnsKey !== streamColumnsKey;
 			streamSignature = signature;
 			streamColumnsKey = columnsKey;
@@ -645,9 +660,11 @@
 	async function loadStreamPrevious() {
 		const reference = streamChapters[0]?.navigation.previous;
 		if (!reference || flowColumns.length === 0 || loadingPrevious) return;
+		const generation = streamGeneration;
 		loadingPrevious = true;
 		try {
 			const chapter = await fetchStreamChapter(reference);
+			if (generation !== streamGeneration) return;
 			// Capture immediately before the mutation, not before the request: touch momentum may continue
 			// while the chapter is in flight and that genuine user movement must not be rolled back.
 			const oldHeights = flowColumns.map((column) => column?.scrollHeight ?? 0);
@@ -667,20 +684,24 @@
 				}
 			}
 		} finally {
-			loadingPrevious = false;
+			if (generation === streamGeneration) loadingPrevious = false;
 		}
 	}
 
 	async function loadStreamNext() {
 		const reference = streamChapters.at(-1)?.navigation.next;
 		if (!reference || loadingNext) return;
+		const generation = streamGeneration;
 		loadingNext = true;
 		try {
-			streamChapters.push(await fetchStreamChapter(reference));
+			const chapter = await fetchStreamChapter(reference);
+			if (generation !== streamGeneration) return;
+			streamChapters.push(chapter);
 			await tick();
+			if (generation !== streamGeneration) return;
 			syncFlowColumns(activeFlowSource);
 		} finally {
-			loadingNext = false;
+			if (generation === streamGeneration) loadingNext = false;
 		}
 	}
 
@@ -718,10 +739,30 @@
 		addressBarTimer = setTimeout(() => {
 			addressBarTimer = undefined;
 			const path = referencePath({ book, chapter, verse });
-			if (path === page.url.pathname) return;
-			replaceState(`${path}${page.url.search}${page.url.hash}`, page.state);
+			if (path === window.location.pathname) return;
+			replaceState(`${path}${window.location.search}${window.location.hash}`, page.state);
 		}, 200);
 	}
+
+	/** Cancels delayed work before it can apply an old chapter's position to a new navigation. */
+	function cancelScheduledReaderWork() {
+		if (flowSyncTimer) clearTimeout(flowSyncTimer);
+		flowSyncTimer = undefined;
+		if (addressBarTimer) clearTimeout(addressBarTimer);
+		addressBarTimer = undefined;
+		for (const timer of suppressFlowTimers) {
+			if (timer) clearTimeout(timer);
+		}
+		suppressFlowTimers = [];
+		suppressedFlowColumns.clear();
+	}
+
+	beforeNavigate(() => {
+		streamGeneration += 1;
+		cancelScheduledReaderWork();
+	});
+
+	onDestroy(cancelScheduledReaderWork);
 
 	/**
 	 * Finds the element for a verse within a flow column, matching a ranged block (a commentary entry or
@@ -947,7 +988,11 @@
 	}
 </script>
 
-<svelte:window onpointermove={onColumnResizeMove} onpointerup={onColumnResizeEnd} />
+<svelte:window
+	onpointermove={onColumnResizeMove}
+	onpointerup={onColumnResizeEnd}
+	onpopstate={() => restoreStrongFromHash(window.location.hash)}
+/>
 
 <svelte:head>
 	<title>{data.fullTitle} — Akribos</title>


### PR DESCRIPTION
## Summary

- add every Strong-word click and explicit sidebar close to browser history
- restore sidebar state for both full navigations and shallow `popstate` traversals
- keep scroll-driven URL updates out of history and discard stale scroll timers or chapter requests after navigation
- document the Reader history invariants and cover the behavior with Playwright regressions

## Root cause

The sidebar used `replaceState`, so opening or switching Strong entries overwrote the current Reader history entry. Its state was also restored from SvelteKit's route URL, which does not react to shallow history changes. Delayed Reader work could additionally update a newly navigated URL or chapter stream.

## Validation

- `pnpm check`
- `pnpm test:e2e:only e2e/reader.e2e.ts` — 45 passed
- `pnpm exec playwright test --workers=1` after a fresh E2E database seed — 88 passed

Closes #111
