### PR TITLE
Sichtbare Versposition am oberen Text-Fade ausrichten

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ Wichtige Scroll-Invarianten:
   zwingend **pro Spalte**: Eine Interaktion darf nur die Sperre ihrer eigenen Spalte aufheben, weil
   verspätete Scroll-Events automatisch ausgerichteter Nebenspalten sonst die Quelle übernehmen.
 - `syncFlowColumns()` richtet andere, verknüpfte Spalten am ersten sichtbaren
-  `[data-verse-key]` aus. Zusammengefasste Versbereiche werden über `data-verse-end` berücksichtigt.
+  `[data-verse-key]` aus. Die Ankerlinie liegt an der Unterkante des oberen Text-Fades, damit URL und
+  Suchfeld bereits beim Eintritt eines Verses in den Fade zum nächsten Vers wechseln. Zusammengefasste
+  Versbereiche werden über `data-verse-end` berücksichtigt.
 - Beim Voranstellen eines Kapitels müssen sowohl `scrollHeight` als auch `scrollTop` unmittelbar
   **vor** der DOM-Mutation (nach dem Fetch) gespeichert werden. So bleibt Touch-Momentum während des
   Fetches erhalten. Browser-Scroll-Anchoring kann `scrollTop` während `tick()` selbst verändern; eine

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -338,6 +338,40 @@ test('flowing text keeps columns scroll-synchronized', async ({ page }) => {
 	await expect(reader).toBeVisible();
 });
 
+test('the visible reference advances when a verse enters the top fade', async ({ page }) => {
+	await page.route('**/api/reader/**', (route) => route.abort());
+	await page.setViewportSize({ width: 900, height: 300 });
+	await page.goto('/Joh3');
+
+	const column = page.locator('.flow-column').first();
+	await page.waitForTimeout(120);
+	const position = await column.evaluate((element) => {
+		const verse = element.querySelector<HTMLElement>('[data-verse-key="43:3:16"]')!;
+		const fade = document.querySelector<HTMLElement>('.flow-fade-grid .flow-edge-fade.top')!;
+		const columnTop = element.getBoundingClientRect().top;
+		const fadeHeight = fade.getBoundingClientRect().height;
+		const distance = verse.getBoundingClientRect().bottom - (columnTop + fadeHeight - 2);
+		// Use the reader's wheel path to mark this column as the genuine source, then dispatch the
+		// resulting scroll synchronously so the regression does not depend on browser event timing.
+		element.dispatchEvent(
+			new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: distance / 0.55 })
+		);
+		element.dispatchEvent(new Event('scroll'));
+		return {
+			fadeHeight: fade.getBoundingClientRect().height,
+			verseBottom: verse.getBoundingClientRect().bottom - columnTop
+		};
+	});
+
+	// Verse 16 is still below the old 12px anchor, but already inside the 24px fade veil.
+	expect(position.fadeHeight).toBe(24);
+	expect(position.verseBottom).toBeGreaterThan(12);
+	expect(position.verseBottom).toBeLessThan(position.fadeHeight);
+	await expect(page.getByPlaceholder('Bibelstelle, Wort oder Strong-Nummer')).toHaveValue(
+		'Joh 3,17'
+	);
+});
+
 test('a delayed follower scroll event cannot steal a rapidly reused source column', async ({
 	page
 }) => {

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -150,6 +150,8 @@
 	 *  stream, this one only cares whether the *columns* changed. */
 	let columnWidthsKey = data.columns.map((column) => column.resource.id).join(',');
 	const MIN_COLUMN_FRACTION = 0.12;
+	/** The address/sync anchor sits at the inner edge of the top fade, not beneath its veil. */
+	const FLOW_EDGE_FADE_PX = 24;
 
 	$effect(() => {
 		const key = data.columns.map((column) => column.resource.id).join(',');
@@ -720,9 +722,8 @@
 	 * whatever chapter and verse are actually on screen while scrolling. A reload then lands back where
 	 * the reader left off, not at the chapter the click landed on.
 	 *
-	 * Debounced like `scheduleFlowSync`: rewriting the address bar on every scroll frame would be
-	 * needless churn (and fight with `history`'s own rate limits), so it only fires once scrolling has
-	 * settled for a moment.
+	 * The search field follows the visible anchor immediately. Only the actual address-bar rewrite is
+	 * debounced, avoiding needless churn and `history` rate limits while scrolling continues.
 	 */
 	function scheduleAddressBarUpdate(verseKey: string | undefined) {
 		if (!verseKey) return;
@@ -789,6 +790,13 @@
 		return null;
 	}
 
+	function firstVisibleVerse(source: HTMLElement): HTMLElement | undefined {
+		const sourceTop = source.getBoundingClientRect().top + FLOW_EDGE_FADE_PX;
+		return [...source.querySelectorAll<HTMLElement>('[data-verse-key]')].find(
+			(verse) => verse.getBoundingClientRect().bottom > sourceTop
+		);
+	}
+
 	/**
 	 * Scrolls straight to a reference already in the loaded stream, without a navigation — used both to
 	 * land on a deep-linked verse after a real navigation and, via `jumpToVerse`, to let the header's
@@ -819,7 +827,7 @@
 					column.scrollTop +
 					target.getBoundingClientRect().top -
 					column.getBoundingClientRect().top -
-					12;
+					FLOW_EDGE_FADE_PX;
 				suppressProgrammaticFlowScroll(index);
 				column.scrollTop = next;
 			}
@@ -851,11 +859,9 @@
 		// An unlinked source doesn't drag the others along, and an unlinked column isn't dragged by them
 		// — that decoupling is the whole point of the per-column link toggle.
 		if (unlinkedColumns.has(sourceIndex)) return;
-		const anchorInset = 12;
-		const sourceTop = source.getBoundingClientRect().top + anchorInset;
+		const anchorInset = FLOW_EDGE_FADE_PX;
 		updateVisibleChapter(source, anchorInset);
-		const verses = [...source.querySelectorAll<HTMLElement>('[data-verse-key]')];
-		const anchor = verses.find((verse) => verse.getBoundingClientRect().bottom > sourceTop);
+		const anchor = firstVisibleVerse(source);
 		if (!anchor?.dataset.verseKey) return;
 		if (trackAddress) scheduleAddressBarUpdate(anchor.dataset.verseKey);
 		const anchorVerse = Number(anchor.dataset.verseKey.split(':').at(-1));
@@ -940,9 +946,10 @@
 		// that would make it the sync source are skipped.
 		if (!unlinkedColumns.has(columnIndex)) {
 			activeFlowSource = columnIndex;
+			scheduleAddressBarUpdate(firstVisibleVerse(source)?.dataset.verseKey);
 			scheduleFlowSync(columnIndex);
 		}
-		updateVisibleChapter(source, 12);
+		updateVisibleChapter(source, FLOW_EDGE_FADE_PX);
 		if (source.scrollTop < 500) void loadStreamPrevious();
 		if (source.scrollHeight - source.scrollTop - source.clientHeight < 900) void loadStreamNext();
 	}
@@ -1181,6 +1188,7 @@
 					class="flow-reader"
 					style="--columns: {visibleColumnCount}"
 					style:--column-track={columnTrack}
+					style:--flow-edge-fade-height={`${FLOW_EDGE_FADE_PX}px`}
 					data-testid="flow-reader"
 				>
 					<!-- The splitter belongs to the text it resizes. Keeping its overlay outside the individual
@@ -1709,7 +1717,7 @@
 		position: absolute;
 		right: 1px;
 		left: 1px;
-		height: 1.5rem;
+		height: var(--flow-edge-fade-height);
 		opacity: 0;
 		transition: opacity 140ms ease;
 	}


### PR DESCRIPTION
## Änderungen

- verwendet einen gemeinsamen 24-px-Wert für die Höhe des oberen Text-Fades und die Reader-Ankerlinie
- ermittelt den sichtbaren Vers an der Unterkante des Fades statt bei 12 px
- aktualisiert das Suchfeld bereits im echten Scroll-Event, während der eigentliche URL-Schreibvorgang weiterhin entprellt bleibt
- richtet programmatische Sprünge, Kapitelerkennung und Spaltensynchronisierung an derselben Linie aus
- ergänzt einen Browser-Regressionstest für den Übergang innerhalb des Fades

## Ursache

Die Fade-Fläche war 24 px hoch, die sichtbare Versposition wurde jedoch nur 12 px unterhalb der Spaltenoberkante ermittelt. Deshalb blieb der vorherige Vers im Suchfeld, obwohl er visuell bereits in den ausgeblendeten Bereich gerutscht war.

## Validierung

- `pnpm check`
- `pnpm lint`
- gezielter Playwright-Regressionstest
- `pnpm test:e2e` — 90 Tests bestanden

Closes #119