### PR TITLE
Reader-Position beim Übersetzungswechsel beibehalten

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,10 @@ Wichtige Scroll-Invarianten:
   Berechnung aus dem nachträglichen Wert kompensiert doppelt und erzeugt Sprünge.
 - Die URL wird beim Lesen mit `replaceState` nachgeführt. `reader-location.svelte.ts` koppelt diese
   Position an das Suchfeld, ohne eine Servernavigation auszulösen.
+- Nach dem Wechsel oder Hinzufügen einer Ressource navigiert der Reader explizit zu der in
+  `readerLocation` sichtbaren Referenz. Die flache `replaceState`-URL allein ändert SvelteKits intern
+  geladene Route nicht; ein bloßes Invalidieren würde deshalb wieder das ursprünglich geladene Kapitel
+  anzeigen.
 - Nach einer echten Reader-Navigation müssen verzögerte Scroll-/Adressleisten-Timer und noch laufende
   Kapitel-Nachladungen verworfen werden; sie dürfen niemals den neuen Kapitelstream oder dessen URL
   verändern. Die Strong-Seitenleiste wird nach History-Navigationen aus `window.location.hash`

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -669,6 +669,35 @@ test('the column selection persists across navigations', async ({ page }) => {
 	await expect(page.locator('#column-0')).toContainText('Schlicht');
 });
 
+test('switching a translation keeps the currently visible chapter', async ({ page }) => {
+	await page.setViewportSize({ width: 900, height: 300 });
+	await page.goto('/1Mo1');
+
+	const column = page.locator('.flow-column').first();
+	const nextChapter = column.locator('[data-chapter-key="1:2"]');
+	await expect(nextChapter).toBeAttached();
+	await column.dispatchEvent('pointerdown');
+	await column.evaluate(
+		(element, scrollTop) => {
+			element.scrollTop = scrollTop;
+		},
+		await nextChapter.evaluate((element) => (element as HTMLElement).offsetTop)
+	);
+	await expect(page).toHaveURL(/\/1Mo2,1$/);
+
+	await page.locator('#column-0').click();
+	await page.getByRole('button', { name: 'Bibeln' }).click();
+	await page
+		.locator('form[action="?/setColumn"]')
+		.filter({ has: page.locator('input[name="resource"][value="SEEDPLAIN"]') })
+		.getByRole('button')
+		.click();
+
+	await expect(page.locator('#column-0')).toContainText('Schlicht');
+	await expect(page).toHaveURL(/\/1Mo2,1$/);
+	await expect(column.locator('[data-chapter-key="1:2"]')).toBeAttached();
+});
+
 test('a closed column can be opened again', async ({ page }) => {
 	await page.goto('/Joh3');
 	await expect(page.locator('button[id^="column-"]')).toHaveCount(2);

--- a/src/lib/components/TranslationDialog.svelte
+++ b/src/lib/components/TranslationDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { goto } from '$app/navigation';
 	import { t } from '$lib/i18n';
 	import type { ReadableResource } from '$lib/server/repositories/resources';
 
@@ -23,6 +24,7 @@
 
 	type Context = {
 		action: '?/setColumn' | '?/addColumn';
+		readerUrl: string;
 		index?: number;
 		selectedId?: string;
 		chosen: string[];
@@ -196,11 +198,16 @@
 							<form
 								method="POST"
 								action={context.action}
-								use:enhance={() =>
-									async ({ update }) => {
+								use:enhance={() => {
+									const readerUrl = context?.readerUrl;
+									return async ({ result, update }) => {
 										close();
-										await update({ reset: false });
-									}}
+										await update({ reset: false, invalidateAll: result.type !== 'success' });
+										if (result.type === 'success' && readerUrl) {
+											await goto(readerUrl, { replaceState: true, invalidateAll: true });
+										}
+									};
+								}}
 							>
 								{#if context.index !== undefined}
 									<input type="hidden" name="index" value={context.index} />

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -72,10 +72,15 @@
 	);
 	const visibleColumnCount = $derived(data.columns.length);
 	const chosenResourceIds = $derived(data.columns.map((column) => column.resource.id));
+	function currentReaderUrl(): string {
+		const path = referencePath(readerLocation.reference ?? data.reference);
+		return `${path}${window.location.search}${window.location.hash}`;
+	}
 
 	function openTranslationDialog(index: number) {
 		translationDialog?.openAt({
 			action: '?/setColumn',
+			readerUrl: currentReaderUrl(),
 			index,
 			selectedId: data.columns[index]?.resource.id,
 			chosen: chosenResourceIds
@@ -83,7 +88,11 @@
 	}
 
 	function openAddDialog() {
-		translationDialog?.openAt({ action: '?/addColumn', chosen: chosenResourceIds });
+		translationDialog?.openAt({
+			action: '?/addColumn',
+			readerUrl: currentReaderUrl(),
+			chosen: chosenResourceIds
+		});
 	}
 
 	function commentaryAt(


### PR DESCRIPTION
## Zusammenfassung

- merkt sich beim Öffnen der Werkauswahl die aktuell sichtbare Reader-Referenz
- lädt nach erfolgreichem Wechsel bzw. Hinzufügen einer Ressource genau diese Referenz neu
- ergänzt einen E2E-Regressionsfall für den Wechsel in einem endlos nachgeladenen Folgekapitel
- dokumentiert die SvelteKit-Invariante für flache Reader-URLs

## Tests

- `pnpm check`
- `pnpm lint`
- `pnpm test:unit --run` (357 Tests)
- `pnpm test:e2e` (90 Tests)

Closes #120