### PR TITLE
Akribos-Logo öffnet die letzte Lesestelle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ liegen in der gleichnamigen `+page.server.ts`. Die REST-Nachladung für Endless 
 
 Die Root-Route `/` zeigt nicht angemeldeten Besuchern die Marketing-Landingpage. Angemeldete Leser
 werden dort unmittelbar zu ihrer im `location`-Cookie gespeicherten letzten Lesestelle weitergeleitet,
-mit Johannes 1 als Fallback. `/about` bleibt als direkte Adresse derselben Landingpage erhalten. Weil
-das Root-Verhalten vom Session-Cookie abhängt, darf die Antwort nicht öffentlich gecacht werden.
+mit Johannes 1 als Fallback. Das Akribos-Logo verlinkt unverändert auf `/` und darf das `location`-Cookie
+nicht löschen, damit es auch von Konto- und Verwaltungsseiten zur letzten Lesestelle zurückführt.
+`/about` bleibt als direkte Adresse derselben Landingpage erhalten. Weil das Root-Verhalten vom
+Session-Cookie abhängt, darf die Antwort nicht öffentlich gecacht werden.
 
 Der Reader zeigt jede Ressource in einer eigenen `.flow-column`. Alle geladenen Kapitel stehen in
 `streamChapters`; DOM-Schlüssel sind `book:chapter` beziehungsweise für Verse `book:chapter:verse`.

--- a/e2e/reader.e2e.ts
+++ b/e2e/reader.e2e.ts
@@ -838,14 +838,15 @@ test('a reference percent-encoded as Latin-1 does not crash the page', async ({ 
 	await expect(page.getByRole('heading', { level: 1 })).toContainText('Könige');
 });
 
-test('the homepage link clears the remembered chapter instead of bouncing back to it', async ({
-	page
-}) => {
+test('the Akribos logo returns to the remembered reader location', async ({ page }) => {
 	await loginAsAdmin(page);
 	await page.goto('/Joh3');
 	await expect(page).toHaveURL(/\/Joh3$/);
+	await page.getByRole('button', { name: 'Konto-Menü' }).click();
+	await page.getByRole('menuitem', { name: 'Mein Konto' }).click();
+	await expect(page).toHaveURL(/\/account$/);
 
 	await page.getByRole('link', { name: 'Akribos – Startseite' }).click();
 
-	await expect(page).toHaveURL(/\/Joh1$/);
+	await expect(page).toHaveURL(/\/Joh3$/);
 });

--- a/src/lib/components/SiteHeader.svelte
+++ b/src/lib/components/SiteHeader.svelte
@@ -105,17 +105,6 @@
 	}
 
 	/**
-	 * `/` on its own resumes the last chapter read, via a cookie — useful when typed directly, but it
-	 * means this link would otherwise just bounce a click straight back to wherever the reader already
-	 * is. Clearing the cookie first makes "Startseite" actually mean home; `data-sveltekit-preload-data
-	 * ="off"` on the link matters too, or hovering it would preload `/`'s data — reading the cookie —
-	 * before this handler ever runs, and the click would reuse that stale, already-fetched redirect.
-	 */
-	function goHome(): void {
-		document.cookie = 'location=; path=/; max-age=0; samesite=lax';
-	}
-
-	/**
 	 * Typing anywhere focuses the search box, as on the old site, and the arrow keys page through
 	 * chapters. Both are skipped while a field or a modifier key is in play.
 	 */
@@ -157,13 +146,7 @@
 	<div
 		class="mx-auto flex h-[var(--header-height)] max-w-[var(--content-max-width)] items-center gap-2 px-3 pt-0.5 sm:gap-5 sm:px-5"
 	>
-		<a
-			href="/"
-			onclick={goHome}
-			data-sveltekit-preload-data="off"
-			class="group shrink-0 focus-visible:rounded-sm"
-			aria-label="Akribos – Startseite"
-		>
+		<a href="/" class="group shrink-0 focus-visible:rounded-sm" aria-label="Akribos – Startseite">
 			<img src="/logo.png" alt="Akribos" class="hidden h-10 w-auto sm:block" />
 			<img src="/icon.png" alt="" class="size-9 rounded-sm sm:hidden" />
 		</a>


### PR DESCRIPTION
## Zusammenfassung

- lässt das Akribos-Logo wieder unverändert auf `/` verweisen
- bewahrt dabei das `location`-Cookie, sodass angemeldete Leser an ihrer letzten Stelle landen
- ersetzt den bisherigen Gegen-Test durch den gemeldeten Weg über „Mein Konto“
- dokumentiert das Verhalten als Reader-Invariante

## Tests

- `pnpm check`
- `pnpm lint`
- `pnpm test:unit --run` (357 Tests)
- `pnpm test:e2e` (89 Tests)

Closes #121