### PR TITLE
Highlight-Text im Darkmode lesbar machen

### DIFF
--- a/e2e/highlights.e2e.ts
+++ b/e2e/highlights.e2e.ts
@@ -163,6 +163,52 @@ test('selecting an entire verse highlights it for every translation, like the ve
 	await expect(seedplainVerse).toHaveCSS('background-color', 'rgb(255, 241, 198)');
 });
 
+/**
+ * Perceptual lightness (0 dark, 1 light) of a computed `color` value, whichever notation the browser
+ * serialized it in — recent Chromium reports `oklch(L C H)` for colors declared via modern CSS color
+ * functions, where `L` already is that lightness, rather than `rgb(r g b)`.
+ */
+function lightness(color: string): number {
+	const oklch = /^oklch\(([\d.]+)/.exec(color);
+	if (oklch) return Number(oklch[1]);
+	const [r, g, b] = color
+		.match(/\d+/g)!
+		.slice(0, 3)
+		.map((value) => Number(value) / 255);
+	return 0.2126 * r! + 0.7152 * g! + 0.0722 * b!;
+}
+
+test('highlighted text stays dark, readable ink in dark mode, not the light body text color', async ({
+	page
+}) => {
+	await register(page, uniqueEmail());
+
+	await page.goto('/Joh3');
+	await selectVerseText(page, 'SEEDDE', '43:3:16', 'er seinen');
+	await page.locator('.swatches .swatch').first().click();
+
+	const partialHighlight = page
+		.locator('.flow-column[data-resource-id="SEEDDE"] [data-verse-key="43:3:16"] .partial-highlight')
+		.first();
+	const wholeVerse = page.locator(
+		'.flow-column[data-resource-id="SEEDDE"] [data-verse-key="43:3:17"]'
+	);
+	await selectVerseText(page, 'SEEDDE', '43:3:17');
+	await page.locator('.swatches .swatch').first().click();
+
+	await page.getByRole('button', { name: 'Dunkles Design' }).click();
+
+	// The dark-mode body text color is light; a highlighted run must not inherit it, since the
+	// highlighter palette stays light pastel backgrounds in every theme.
+	const bodyColor = await page.evaluate(() => getComputedStyle(document.body).color);
+	expect(lightness(bodyColor)).toBeGreaterThan(0.7);
+
+	const partialColor = await partialHighlight.evaluate((el) => getComputedStyle(el).color);
+	const wholeVerseColor = await wholeVerse.evaluate((el) => getComputedStyle(el).color);
+	expect(lightness(partialColor)).toBeLessThan(0.4);
+	expect(lightness(wholeVerseColor)).toBeLessThan(0.4);
+});
+
 test('a whole-verse highlight created before partial highlights existed keeps applying to every translation', async ({
 	page
 }) => {

--- a/src/lib/components/VerseText.svelte
+++ b/src/lib/components/VerseText.svelte
@@ -112,6 +112,7 @@
 			class="strong"
 			class:active={matchesStrong(item.segment, activeStrong) ||
 				matchesStrong(item.segment, hoverStrong)}
+			class:has-highlight={item.color}
 			data-strong={item.segment.strong}
 			title={item.segment.morph ?? undefined}
 			style:background-color={item.color}
@@ -124,7 +125,7 @@
 			}}>{item.segment.text}</button
 		>
 	{:else if item.kind === 'em'}
-		<em style:background-color={item.color}>{item.text}</em>
+		<em class:has-highlight={item.color} style:background-color={item.color}>{item.text}</em>
 	{:else if item.kind === 'note'}
 		<Footnote marker={item.segment.marker} text={item.segment.text} />
 	{:else if item.kind === 'wj'}
@@ -194,8 +195,13 @@
 	}
 
 	/* A translation-specific highlight, painted directly on the run of text it covers rather than the
-	   whole `.flow-verse`, which is what a whole-verse highlight still uses. */
-	.partial-highlight {
+	   whole `.flow-verse`, which is what a whole-verse highlight still uses. The highlighter palette is
+	   made of light pastel backgrounds, so the text on top must stay dark ink in both themes — it must
+	   not follow the dark-mode body text color, which would turn light-on-light and unreadable. */
+	.partial-highlight,
+	.strong.has-highlight,
+	em.has-highlight {
 		border-radius: 0.15rem;
+		color: oklch(0.28 0.02 90);
 	}
 </style>

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -1571,6 +1571,7 @@
 														data.reference.verse !== undefined &&
 														cell.verse <= data.reference.verse &&
 														(cell.verseEnd ?? cell.verse) >= data.reference.verse}
+													class:has-highlight={mark?.color}
 													style:background-color={mark?.color}
 												>
 													<span class="verse-lead">
@@ -2115,6 +2116,12 @@
 
 	.flow-verse.highlighted {
 		background-color: color-mix(in oklab, var(--color-accent-500) 12%, transparent);
+	}
+
+	/* A whole-verse highlight paints a light pastel background regardless of theme, so its text must
+	   stay dark ink rather than follow the dark-mode body color, which would turn light-on-light. */
+	.flow-verse.has-highlight {
+		color: oklch(0.28 0.02 90);
 	}
 
 	.flow-reference {


### PR DESCRIPTION
## Zusammenfassung
- Hervorgehobener Verstext (ganzer Vers und übersetzungsspezifische Wortbereiche) setzte nur `background-color`; die Textfarbe fiel auf die Theme-Textfarbe zurück.
- Im Darkmode wird diese Textfarbe hell, wodurch heller Text auf dem hellen Pastell-Highlight landet und unlesbar wird.
- Erzwingt jetzt eine feste dunkle Tintenfarbe für hervorgehobenen Text in beiden Themes, da die Highlight-Palette themenunabhängig hell bleibt.

## Änderungen
- `src/lib/components/VerseText.svelte`: `.partial-highlight`, hervorgehobene Strong-Wörter und `em`-Hervorhebungen erhalten eine feste dunkle Textfarbe.
- `src/routes/[...reference]/+page.svelte`: Ganzer-Vers-Highlight (`.flow-verse.has-highlight`) ebenso.
- `e2e/highlights.e2e.ts`: neuer Regressionstest, der im Darkmode prüft, dass hervorgehobener Text deutlich dunkler bleibt als der normale (helle) Fließtext.

Fixes #141

## Test plan
- [x] `pnpm check`
- [x] `pnpm lint` (nur betroffene Dateien, siehe Hinweis unten)
- [x] `pnpm test:unit --run src/lib/bible/segments.spec.ts`
- [x] `pnpm test:e2e` (alle 105 Tests grün)
- [x] Test verifiziert: schlägt ohne den Fix fehl, besteht mit dem Fix

Hinweis: `pnpm lint` (voller Lauf) meldet Formatierungsprobleme in einem vorbestehenden, nicht zu diesem Branch gehörenden Worktree (`.claude/worktrees/new-chooser/...`); die beiden geänderten Dateien selbst sind mit `prettier --check` und `eslint` sauber.