### PR TITLE
Highlight-Menü auf Mobile ohne Umweg über natives Auswahlmenü

### DIFF
--- a/e2e/highlights.e2e.ts
+++ b/e2e/highlights.e2e.ts
@@ -48,15 +48,20 @@ function databaseUrl(): string {
  *
  * `needle` names an exact substring to select; omitting it selects the verse's entire rendered text,
  * which is how a reader would highlight the whole verse (in every translation) by dragging across it.
+ *
+ * `dispatchMouseup: false` leaves the synthetic `mouseup` out, the way a native Android long-press
+ * selection never delivers one to the page — only the browser's own, real `selectionchange` event
+ * follows, which is what the reader's debounced fallback listener has to pick up instead.
  */
 async function selectVerseText(
 	page: Page,
 	resourceId: string,
 	verseKey: string,
-	needle?: string
+	needle?: string,
+	{ dispatchMouseup = true }: { dispatchMouseup?: boolean } = {}
 ): Promise<void> {
 	await page.evaluate(
-		({ resourceId, verseKey, needle }) => {
+		({ resourceId, verseKey, needle, dispatchMouseup }) => {
 			const column = document.querySelector(`.flow-column[data-resource-id="${resourceId}"]`);
 			const verseEl = column?.querySelector<HTMLElement>(`[data-verse-key="${verseKey}"]`);
 			if (!verseEl) throw new Error(`verse not found: ${resourceId} ${verseKey}`);
@@ -88,9 +93,9 @@ async function selectVerseText(
 			const selection = window.getSelection();
 			selection?.removeAllRanges();
 			selection?.addRange(range);
-			verseEl.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+			if (dispatchMouseup) verseEl.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
 		},
-		{ resourceId, verseKey, needle }
+		{ resourceId, verseKey, needle, dispatchMouseup }
 	);
 }
 
@@ -139,6 +144,19 @@ test('a partial highlight applies only in the translation it was selected in', a
 	await page.reload();
 	await expect(seeddeHighlight.first()).toHaveCSS('background-color', 'rgb(255, 241, 198)');
 	await expect(seedplainHighlight).toHaveCount(0);
+});
+
+test('a selection made without a mouseup/touchend still opens the menu, via selectionchange', async ({
+	page
+}) => {
+	await register(page, uniqueEmail());
+
+	await page.goto('/Joh3');
+	// No synthetic `mouseup` here — this is the native-long-press case from issue #142, where the
+	// gesture's own `touchend` never reaches the page and only a real `selectionchange` follows.
+	await selectVerseText(page, 'SEEDDE', '43:3:16', 'er seinen', { dispatchMouseup: false });
+
+	await expect(page.locator('.swatches .swatch')).toHaveCount(10);
 });
 
 test('selecting an entire verse highlights it for every translation, like the verse-number menu', async ({

--- a/src/routes/[...reference]/+page.svelte
+++ b/src/routes/[...reference]/+page.svelte
@@ -486,12 +486,32 @@
 		);
 	}
 
+	/**
+	 * On Android, a long-press-to-select gesture is consumed by the browser's own selection UI
+	 * (handles plus a copy/share bubble); the gesture's own `touchend` never reaches this document
+	 * listener, so `onVerseTextSelection` only used to run on the *next* touch — typically the tap a
+	 * reader makes to dismiss that native bubble. `selectionchange` fires reliably the instant the
+	 * selection is created, native long-press included, so it is debounced in as an additional trigger
+	 * that does not depend on `touchend` being delivered. The debounce also covers a mouse drag, where
+	 * `selectionchange` fires on every character crossed: by the time it settles, `mouseup` has already
+	 * opened the menu and cleared the selection, so the delayed call below is a harmless no-op.
+	 */
+	let selectionChangeTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function onSelectionChangeDebounced() {
+		clearTimeout(selectionChangeTimer);
+		selectionChangeTimer = setTimeout(onVerseTextSelection, 120);
+	}
+
 	$effect(() => {
 		document.addEventListener('mouseup', onVerseTextSelection);
 		document.addEventListener('touchend', onVerseTextSelection);
+		document.addEventListener('selectionchange', onSelectionChangeDebounced);
 		return () => {
 			document.removeEventListener('mouseup', onVerseTextSelection);
 			document.removeEventListener('touchend', onVerseTextSelection);
+			document.removeEventListener('selectionchange', onSelectionChangeDebounced);
+			clearTimeout(selectionChangeTimer);
 		};
 	});
 


### PR DESCRIPTION
## Zusammenfassung
Auf Android wird eine Textauswahl per Long-Press von der nativen Browser-Auswahl-UI (Griffe + Kopieren/Teilen-Bubble) abgefangen; das `touchend` dieser Geste erreicht die Seite dabei nicht. Bisher hörte der Reader nur auf `mouseup`/`touchend`, sodass das App-eigene Highlight-Menü erst beim *nächsten* Touch erschien — typischerweise erst, nachdem man das native Menü extra weggetippt hat.

## Änderungen
- `src/routes/[...reference]/+page.svelte`: zusätzlich ein (debounced) `selectionchange`-Listener als Fallback-Trigger für `onVerseTextSelection`. `selectionchange` feuert zuverlässig sofort bei jeder Selektion, auch bei nativem Long-Press. Die Debounce-Verzögerung sorgt dafür, dass eine Maus-Drag-Selektion (bei der `selectionchange` bei jedem Zeichen feuert) nicht mehrfach das Menü neu positioniert – zum Zeitpunkt des verzögerten Aufrufs hat `mouseup` die Selektion bereits verarbeitet und geleert, der zusätzliche Aufruf ist dann ein No-op.
- `e2e/highlights.e2e.ts`: neuer Regressionstest, der eine Selektion ganz ohne synthetisches `mouseup`/`touchend` setzt (genau der Android-Fall) und prüft, dass das Menü trotzdem über das reale `selectionchange`-Event erscheint.

Fixes #142

## Test plan
- [x] `pnpm check`
- [x] `pnpm lint` (nur betroffene Dateien; siehe Hinweis)
- [x] `pnpm test:unit --run` (402 Tests)
- [x] `pnpm test:e2e` (alle 108 Tests grün)
- [x] Neuer Test verifiziert: schlägt ohne den Fix fehl, besteht mit dem Fix

Hinweis: `pnpm lint` (voller Lauf) meldet Formatierungsprobleme in einem vorbestehenden, nicht zu diesem Branch gehörenden Worktree (`.claude/worktrees/new-chooser/...`); die beiden geänderten Dateien selbst sind mit `prettier --check` und `eslint` sauber.