### PR TITLE
Prettier-Formatierung in highlights.e2e.ts reparieren

### DIFF
--- a/e2e/highlights.e2e.ts
+++ b/e2e/highlights.e2e.ts
@@ -206,7 +206,9 @@ test('highlighted text stays dark, readable ink in dark mode, not the light body
 	await page.locator('.swatches .swatch').first().click();
 
 	const partialHighlight = page
-		.locator('.flow-column[data-resource-id="SEEDDE"] [data-verse-key="43:3:16"] .partial-highlight')
+		.locator(
+			'.flow-column[data-resource-id="SEEDDE"] [data-verse-key="43:3:16"] .partial-highlight'
+		)
 		.first();
 	const wholeVerse = page.locator(
 		'.flow-column[data-resource-id="SEEDDE"] [data-verse-key="43:3:17"]'


### PR DESCRIPTION
## Zusammenfassung
Nach dem Mergen von #143 und #144 schlug `pnpm lint` auf `main` fehl: Die beiden PRs wurden jeweils isoliert korrekt formatiert, aber in Kombination (mehr Inhalt vor der betroffenen Zeile durch #144) überschritt ein `.locator(...)`-Aufruf in `e2e/highlights.e2e.ts` die Prettier-Zeilenbreite.

## Änderungen
- `e2e/highlights.e2e.ts`: `npx prettier --write` angewendet (rein mechanischer Umbruch, keine Logikänderung).

## Test plan
- [x] `pnpm check`
- [x] `prettier --check` / `eslint` auf der Datei
- [x] `pnpm test:e2e` (alle 109 Tests grün)

CI auf `main` (Merge von #143) ist rot: https://github.com/akribos-biblestudy/akribos/actions/runs/31930089608